### PR TITLE
Make game run faster and not crash browser in large games

### DIFF
--- a/src/components/episode/allianceList.tsx
+++ b/src/components/episode/allianceList.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-import { GameState, getById } from "../../model";
+import { canDisplayCliques, GameState, getById } from "../../model";
+import { Centered } from "../layout/centered";
+import { HasText } from "../layout/text";
 import { Portraits } from "../playerPortrait/portraits";
 
 interface AllianceListProps {
@@ -7,6 +9,15 @@ interface AllianceListProps {
 }
 
 export function AllianceList(props: AllianceListProps) {
+    if (!canDisplayCliques(props.gameState))
+        return (
+            <HasText>
+                <Centered>
+                    ⚠️ There are too many players left in the game to display the alliances! Try again when
+                    there are 30 or less! ⚠️
+                </Centered>
+            </HasText>
+        );
     const cliques = props.gameState.cliques;
     const elements: JSX.Element[] = cliques.map((clique, i) => (
         <Portraits

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -15,7 +15,6 @@ import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
 import { generateVetoCompScene } from "./scenes/vetoCompScene";
 import { generateVetoCeremonyScene } from "./scenes/vetoCeremonyScene";
 import { generateEvictionScene } from "./scenes/evictionScene";
-import { MemoryWall } from "../memoryWall";
 import { NextEpisodeButton } from "../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
 import { Scene } from "./scene";
@@ -54,6 +53,7 @@ export function evictHouseguest(gameState: MutableGameState, id: number) {
             hg.superiors.delete(evictee.id);
         });
     }
+    gameState.nonEvictedHouseguests.delete(evictee.id);
     gameState.remainingPlayers--;
 }
 

--- a/src/components/episode/episodeFactory.ts
+++ b/src/components/episode/episodeFactory.ts
@@ -20,6 +20,10 @@ import { EpisodeLog } from "../../model/logging/episodelog";
 import { generateCliques } from "../../utils/graphTest";
 import { getRelationshipSummary, Targets } from "../../utils/ai/targets";
 
+export function canDisplayCliques(newState: GameState): boolean {
+    return newState.remainingPlayers <= 30;
+}
+
 function firstImpressions(houseguests: Houseguest[]) {
     for (let i = 0; i < houseguests.length; i++) {
         const iMap = houseguests[i].relationships;
@@ -101,7 +105,7 @@ export class EpisodeFactory {
             firstImpressions(newState.houseguests);
         }
         newState.phase++;
-        if (nonEvictedHouseguests(gameState).length > 2) {
+        if (gameState.remainingPlayers > 2) {
             newState.log[newState.phase] = new EpisodeLog();
         }
         // If jury starts this episode, populate superior/inferior data. In the future, every jury ep. (dynamic rels)
@@ -113,7 +117,7 @@ export class EpisodeFactory {
         }
         updatePopularity(newState);
         nonEvictedHouseguests(gameState).length > 2 && updateFriendCounts(newState);
-        newState.cliques = generateCliques(newState);
+        if (canDisplayCliques(newState)) newState.cliques = generateCliques(newState);
         const finalState = new GameState(newState);
         switch (episodeType) {
             case BigBrotherVanilla:

--- a/src/components/episode/episodeFactory.ts
+++ b/src/components/episode/episodeFactory.ts
@@ -116,7 +116,7 @@ export class EpisodeFactory {
             updatePowerRankings(nonEvictedHouseguests(newState));
         }
         updatePopularity(newState);
-        nonEvictedHouseguests(gameState).length > 2 && updateFriendCounts(newState);
+        gameState.remainingPlayers > 2 && updateFriendCounts(newState);
         if (canDisplayCliques(newState)) newState.cliques = generateCliques(newState);
         const finalState = new GameState(newState);
         switch (episodeType) {

--- a/src/components/mainPage/bulma.scss
+++ b/src/components/mainPage/bulma.scss
@@ -73,3 +73,7 @@ $tabs-link-color: hsl(0, 0%, 86%);
     border-top-right-radius: 4px;
     display: none !important;
 }
+
+.column {
+    padding: 0.25rem;
+}

--- a/src/components/playerPortrait/subtitle.tsx
+++ b/src/components/playerPortrait/subtitle.tsx
@@ -137,7 +137,7 @@ function friendEnemyCountTitle(hero: PortraitProps): string[] {
             ? { friends: hero.friends, enemies: hero.enemies }
             : { friends: 0, enemies: 0 };
     titles.push(
-        `${count.friends} ${RelationshipTypeToSymbol[Relationship.Friend]} | ${count.enemies} ${
+        `${count.friends} ${RelationshipTypeToSymbol[Relationship.Friend]}| ${count.enemies} ${
             RelationshipTypeToSymbol[Relationship.Enemy]
         }${hero.targetingMe ? `| 🎯 ${hero.targetingMe}` : ""}`
     );

--- a/src/components/sidebar/sidebarController.ts
+++ b/src/components/sidebar/sidebarController.ts
@@ -86,9 +86,8 @@ export class SidebarController {
             // Generate a new scene, then jump to it
             const currentGameState = lastEpisode.gameState;
             const newPlayerCount = nonEvictedHouseguests(lastEpisode.gameState).length;
-            const nextEpisodeType = this.season.whichEpisodeType(newPlayerCount);
             if (newPlayerCount > 0) {
-                newEpisode(this.season.renderEpisode(currentGameState, nextEpisodeType));
+                newEpisode(this.season.renderEpisode(currentGameState));
                 this.switchSceneRelative(1);
             }
         }

--- a/src/model/gameState.ts
+++ b/src/model/gameState.ts
@@ -24,8 +24,8 @@ export function randomPlayer(inclusions: Houseguest[], exclusions: Houseguest[] 
     return options[choice];
 }
 
-export function nonEvictedHouseguests(gameState: GameState) {
-    return gameState.houseguests.filter((hg) => !hg.isEvicted);
+export function nonEvictedHouseguests(gameState: GameState): Houseguest[] {
+    return [...gameState.nonEvictedHouseguests.entries()].map(([_, id]) => getById(gameState, id));
 }
 export function getJurors(gameState: GameState): Houseguest[] {
     return gameState.houseguests.filter((hg) => hg.isJury);
@@ -52,6 +52,7 @@ export class GameState {
     // Current state of the game after a phase.
 
     readonly houseguestCache: { [id: number]: Houseguest } = {};
+    readonly nonEvictedHouseguests: Set<number> = new Set<number>();
     readonly houseguests: Houseguest[] = [];
     readonly remainingPlayers: number = 0;
     readonly phase: number = 0;
@@ -74,6 +75,7 @@ export class GameState {
                     id: i,
                     relationships: newRelationshipMap(profiles.length, i),
                 });
+                this.nonEvictedHouseguests.add(i);
                 this.houseguestCache[i] = hg;
                 this.houseguests.push(hg);
             });
@@ -84,6 +86,7 @@ export class GameState {
 export class MutableGameState {
     public houseguests: Houseguest[] = [];
     public houseguestCache: { [id: number]: Houseguest } = {};
+    readonly nonEvictedHouseguests: Set<number> = new Set<number>();
     public remainingPlayers: number = 0;
     public phase: number = 0;
     public previousHOH?: Houseguest;

--- a/src/model/season.ts
+++ b/src/model/season.ts
@@ -1,7 +1,7 @@
 import { BigBrotherVanilla } from "../components/episode/bigBrotherEpisode";
 import { EpisodeFactory } from "../components/episode/episodeFactory";
-import { GameState } from "./gameState";
-import { EpisodeType, Episode } from ".";
+import { GameState, nonEvictedHouseguests } from "./gameState";
+import { Episode } from ".";
 import { BigBrotherFinale } from "../components/episode/bigBrotherFinale";
 import { cast$ } from "../subjects/subjects";
 import { GameOver } from "../components/episode/gameOver";
@@ -10,16 +10,18 @@ export function finalJurySize() {
     return jurors;
 }
 
+// 7 is not a magic number: it is just an arbitrary value which is always overwritten by cast$ before it is read.
 let jurors = 7;
+
 const sub = cast$.subscribe({
-    next: newCast => {
+    next: (newCast) => {
         let players = newCast.length;
         players = Math.round(players * 0.55);
         if (players % 2 === 0) {
             players--;
         }
         jurors = players;
-    }
+    },
 });
 
 export function getFinalists() {
@@ -36,8 +38,29 @@ export class Season {
     // In the future, this would all be customizable,
     // and not just all big brother episodes by default.
 
-    public renderEpisode(gameState: GameState, type: EpisodeType): Episode {
-        return this.factory.nextEpisode(gameState, type);
+    // TODO: I think the way to do this would be to have season asnycronously generate all episodes here,
+    // and then store them in an array,
+    // and then when sidebar calls renderEpisode, I can just pluck them from a pre-calculated array.
+    // The problem being that if it's not there, it's just not there.
+
+    // then maybe renderEpisode needs to become async?
+    // wait
+    // maybe as i generate them
+    /// obviously i generate episode 1 first
+    // then i have a hanging async function that is like "get episode 2"
+    // and it literally just is an awaiting or something? idk
+
+    // like if its array of async () => episode
+    // then if there is NO episode
+    // and the generator is still generating episode 2, then
+
+    //maybe it uses subjects or something
+
+    public renderEpisode(gameState: GameState): Episode {
+        return this.factory.nextEpisode(
+            gameState,
+            this.whichEpisodeType(nonEvictedHouseguests(gameState).length)
+        );
     }
 
     public whichEpisodeType(players: number) {

--- a/src/model/season.ts
+++ b/src/model/season.ts
@@ -57,10 +57,7 @@ export class Season {
     //maybe it uses subjects or something
 
     public renderEpisode(gameState: GameState): Episode {
-        return this.factory.nextEpisode(
-            gameState,
-            this.whichEpisodeType(nonEvictedHouseguests(gameState).length)
-        );
+        return this.factory.nextEpisode(gameState, this.whichEpisodeType(gameState.remainingPlayers));
     }
 
     public whichEpisodeType(players: number) {

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -172,7 +172,7 @@ export function useGoldenVeto(
         } else {
             result = useGoldenVetoPreJury(hero, nominees);
         }
-        if (nonEvictedHouseguests(gameState).length === 4) {
+        if (gameState.remainingPlayers === 4) {
             result = {
                 decision: null,
                 reason: "It doesn't make sense to use the veto here.",


### PR DESCRIPTION
I made the game run faster by optimizing the decision logic, which really should have been done a year ago, but it was never really a problem. 

I also disabled the alliances page for playercount above 30, since it displays literally 1000+ player cards, crashing your browser, and also runs an exponential time algo (bron-kerbosh) to find the maximal cliques. 