### PR TITLE
Winrate bugfixes

### DIFF
--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -54,7 +54,6 @@ export function evictHouseguest(gameState: MutableGameState, id: number) {
             if (hg.superiors[evictee.id] > MAGIC_SUPERIOR_NUMBER) {
                 hg.superiors.size--;
             }
-            delete hg.superiors[evictee.id];
         });
     }
     gameState.nonEvictedHouseguests.delete(evictee.id);

--- a/src/components/episode/episodeFactory.ts
+++ b/src/components/episode/episodeFactory.ts
@@ -20,6 +20,7 @@ import { generateCliques } from "../../utils/generateCliques";
 import { getRelationshipSummary, Targets } from "../../utils/ai/targets";
 import { MAGIC_SUPERIOR_NUMBER } from "../../utils/ai/aiApi";
 import { generateSafetyChain, SafetyChain } from "./safetyChain";
+import _ from "lodash";
 
 export function canDisplayCliques(newState: GameState): boolean {
     return newState.remainingPlayers <= 30;
@@ -67,9 +68,13 @@ function populateSuperiors(houseguests: Houseguest[]) {
 
 function updatePowerRankings(houseguests: Houseguest[]) {
     houseguests.forEach((hg) => {
-        const superiors: any = { ...hg.superiors };
+        const superiors: { [id: number]: number; size?: number } = { ...hg.superiors };
         delete superiors["size"];
-        hg.powerRanking = average(Object.values(superiors));
+        let newSuperiors: { [id: number]: number } = superiors;
+        const nonEvictedHouseguests: Set<number> = new Set<number>(houseguests.map((h) => h.id));
+        newSuperiors = _.filter(newSuperiors, (_, id) => nonEvictedHouseguests.has(parseInt(id)));
+
+        hg.powerRanking = average(Object.values(newSuperiors));
     });
 }
 

--- a/src/components/viewsBar/viewBar.tsx
+++ b/src/components/viewsBar/viewBar.tsx
@@ -7,6 +7,9 @@ import { displayMode$ } from "../../subjects/subjects";
 export class ViewsBar extends React.Component<{ gameState: GameState }, {}> {
     public constructor(props: { gameState: GameState }) {
         super(props);
+        if (!inJury(this.props.gameState) && displayMode$.value === powerMode) {
+            displayMode$.next(popularityMode);
+        }
     }
 
     componentDidUpdate() {

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -224,11 +224,7 @@ function useGoldenVetoPreJury(
     let potentialSave: Houseguest | null = null;
     let alwaysSave: Houseguest | null = null;
     nominees.forEach((nominee) => {
-        const nomineeIsSuperior: boolean = hero.superiors[nominee.id] > MAGIC_SUPERIOR_NUMBER;
-        if (gameState.remainingPlayers - hero.superiors.size - 1 === 1 && !nomineeIsSuperior) {
-            alwaysSave = nominee;
-            reason = `I have to save ${nominee.name}, because they are the last person I can beat.`;
-        }
+        // TODO: Save people who you can beat in the end if you are low winrate
         const relationship = classifyRelationship(
             hero.popularity,
             nominee.popularity,


### PR DESCRIPTION
Fix a couple visual bugs related to the endgame winrate view and jumping around from episode to episode

1: going from gameover screen to pre-jury episodes while in power ranking mode does not switch back to popularity mode

2: while in power rankings mode, selecting a player in a jury episode and jumping to another jury episode in which the selected player is not evicted will cause the evictee in the episode you jumped to to have no color or subtitle