### PR TITLE
Triple eviction

### DIFF
--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -93,7 +93,7 @@ export function generateBBVanillaScenes(
     let hohCompScene: Scene;
     const scenes: Scene[] = [];
 
-    [currentGameState, hohCompScene, hoh] = generateHohCompScene(initialGamestate, doubleEviction);
+    [currentGameState, hohCompScene, hoh] = generateHohCompScene(initialGamestate, { doubleEviction });
     scenes.push(hohCompScene);
 
     let nomCeremonyScene;

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -98,11 +98,9 @@ export function generateBBVanillaScenes(
 
     let nomCeremonyScene;
     let nominees: Houseguest[];
-    [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(
-        currentGameState,
-        hoh,
-        doubleEviction
-    );
+    [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, hoh, {
+        doubleEviction,
+    });
     scenes.push(nomCeremonyScene);
 
     let vetoCompScene;
@@ -110,8 +108,7 @@ export function generateBBVanillaScenes(
     [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
         currentGameState,
         hoh,
-        nominees[0],
-        nominees[1],
+        nominees,
         doubleEviction
     );
     scenes.push(vetoCompScene);
@@ -122,7 +119,7 @@ export function generateBBVanillaScenes(
         hoh,
         nominees,
         povWinner,
-        doubleEviction
+        { doubleEviction, finalNominees: 2 }
     );
     scenes.push(vetoCeremonyScene);
 

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -58,7 +58,7 @@ export function Tabs(): JSX.Element {
     );
 }
 
-export function generateBbVanilla(initialGamestate: GameState): BigBrotherVanillaEpisode {
+export function generateBbVanilla(initialGamestate: GameState): Episode {
     const episode = generateBBVanillaScenes(initialGamestate);
     const content = (
         <HasText>
@@ -68,7 +68,7 @@ export function generateBbVanilla(initialGamestate: GameState): BigBrotherVanill
             <NextEpisodeButton />
         </HasText>
     );
-    return new BigBrotherVanillaEpisode({
+    return new Episode({
         title: episode.title,
         scenes: episode.scenes,
         content,
@@ -77,23 +77,7 @@ export function generateBbVanilla(initialGamestate: GameState): BigBrotherVanill
         type: BigBrotherVanilla,
     });
 }
-export class BigBrotherVanillaEpisode extends Episode {
-    readonly title: string;
-    readonly scenes: Scene[];
-    readonly content: JSX.Element;
-    readonly initialGamestate: GameState;
-    readonly gameState: GameState;
-    readonly type = BigBrotherVanilla;
 
-    public constructor(init: InitEpisode) {
-        super(init);
-        this.title = init.title;
-        this.scenes = init.scenes;
-        this.content = init.content;
-        this.gameState = init.gameState;
-        this.initialGamestate = init.initialGamestate || init.gameState;
-    }
-}
 export function generateBBVanillaScenes(
     initialGamestate: GameState,
     doubleEviction: boolean = false

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -6,7 +6,7 @@ import { generateVetoCeremonyScene } from "./scenes/vetoCeremonyScene";
 import { generateEvictionScene } from "./scenes/evictionScene";
 import { NextEpisodeButton } from "../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
-import { Scene } from "./scene";
+import { Scene } from "./scenes/scene";
 import { HasText } from "../layout/text";
 import styled from "styled-components";
 import { weekStartTab$ } from "../../subjects/subjects";
@@ -71,7 +71,6 @@ export function defaultContent(initialGameState: GameState) {
 
 export function generateBbVanilla(initialGamestate: GameState): Episode {
     const episode = generateBBVanillaScenes(initialGamestate);
-
     return new Episode({
         title: episode.title,
         scenes: episode.scenes,

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -124,12 +124,10 @@ export function generateBBVanillaScenes(
     scenes.push(vetoCeremonyScene);
 
     let evictionScene;
-    [currentGameState, evictionScene] = generateEvictionScene(
-        currentGameState,
-        hoh,
-        nominees,
-        doubleEviction
-    );
+    [currentGameState, evictionScene] = generateEvictionScene(currentGameState, hoh, nominees, {
+        doubleEviction: false,
+        votingTo: "Evict",
+    });
     scenes.push(evictionScene);
     const title = `Week ${currentGameState.phase}`;
     return { gameState: currentGameState, scenes, title };

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -1,4 +1,4 @@
-import { GameState, Houseguest, EpisodeType, Episode, InitEpisode } from "../../model";
+import { GameState, Houseguest, EpisodeType, Episode } from "../../model";
 import { generateHohCompScene } from "./scenes/hohCompScene";
 import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
 import { generateVetoCompScene } from "./scenes/vetoCompScene";
@@ -58,20 +58,23 @@ export function Tabs(): JSX.Element {
     );
 }
 
-export function generateBbVanilla(initialGamestate: GameState): Episode {
-    const episode = generateBBVanillaScenes(initialGamestate);
-    const content = (
+export function defaultContent(initialGameState: GameState) {
+    return (
         <HasText>
             <Tabs />
-            <WeekStartWrapper gameState={initialGamestate} />
+            <WeekStartWrapper gameState={initialGameState} />
             <br />
             <NextEpisodeButton />
         </HasText>
     );
+}
+
+export function generateBbVanilla(initialGamestate: GameState): Episode {
+    const episode = generateBBVanillaScenes(initialGamestate);
+
     return new Episode({
         title: episode.title,
         scenes: episode.scenes,
-        content,
         gameState: new GameState(episode.gameState),
         initialGamestate,
         type: BigBrotherVanilla,

--- a/src/components/episode/bigBrotherFinale.tsx
+++ b/src/components/episode/bigBrotherFinale.tsx
@@ -18,7 +18,7 @@ export const BigBrotherFinale: EpisodeType = {
     generate: generateBbFinale,
 };
 
-export function generateBbFinale(initialGameState: GameState): BigBrotherFinaleEpisode {
+export function generateBbFinale(initialGameState: GameState): Episode {
     const title = "Finale";
     const content = (
         <HasText>
@@ -37,21 +37,5 @@ export function generateBbFinale(initialGameState: GameState): BigBrotherFinaleE
     scenes.push(finalEviction);
     const [gameState, juryScene] = juryVoteScene(currentGameState);
     scenes.push(juryScene);
-    return new BigBrotherFinaleEpisode({ gameState, content, title, scenes, type: BigBrotherFinale });
-}
-
-export class BigBrotherFinaleEpisode extends Episode {
-    readonly title: string;
-    readonly scenes: Scene[];
-    readonly content: JSX.Element;
-    readonly gameState: GameState;
-    readonly type = BigBrotherFinale;
-
-    public constructor(init: InitEpisode) {
-        super(init);
-        this.title = init.title;
-        this.scenes = init.scenes;
-        this.content = init.content;
-        this.gameState = init.gameState;
-    }
+    return new Episode({ gameState, content, title, scenes, type: BigBrotherFinale });
 }

--- a/src/components/episode/bigBrotherFinale.tsx
+++ b/src/components/episode/bigBrotherFinale.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { EpisodeType, Episode, InitEpisode } from "./episodes";
-import { Scene } from "./scene";
+import { Scene } from "./scenes/scene";
 import { GameState } from "../../model";
 import { MemoryWall } from "../memoryWall";
 import { NextEpisodeButton } from "../nextEpisodeButton/nextEpisodeButton";

--- a/src/components/episode/doubleEvictionEpisode.tsx
+++ b/src/components/episode/doubleEvictionEpisode.tsx
@@ -32,6 +32,7 @@ export function generateDoubleEviction(initialGamestate: GameState): Episode {
     const gameState = new GameState(currentGameState);
     return new Episode({
         gameState,
+        initialGamestate,
         title: episode.title,
         scenes,
         type: DoubleEviction,

--- a/src/components/episode/doubleEvictionEpisode.tsx
+++ b/src/components/episode/doubleEvictionEpisode.tsx
@@ -2,7 +2,7 @@ import { GameState } from "../../model";
 import { generateBBVanillaScenes } from "./bigBrotherEpisode";
 import { Episode, EpisodeType } from "./episodes";
 import React from "react";
-import { Scene } from "./scene";
+import { Scene } from "./scenes/scene";
 
 export const DoubleEviction: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
@@ -29,9 +29,8 @@ export function generateDoubleEviction(initialGamestate: GameState): Episode {
         })
     );
 
-    const gameState = new GameState(currentGameState);
     return new Episode({
-        gameState,
+        gameState: new GameState(currentGameState),
         initialGamestate,
         title: episode.title,
         scenes,

--- a/src/components/episode/doubleEvictionEpisode.tsx
+++ b/src/components/episode/doubleEvictionEpisode.tsx
@@ -1,9 +1,6 @@
 import { GameState } from "../../model";
-import { HasText } from "../layout/text";
-import { NextEpisodeButton } from "../nextEpisodeButton/nextEpisodeButton";
-import { generateBBVanillaScenes, Tabs } from "./bigBrotherEpisode";
-import { WeekStartWrapper } from "./bigBrotherWeekstartWrapper";
-import { Episode, EpisodeType, InitEpisode } from "./episodes";
+import { generateBBVanillaScenes } from "./bigBrotherEpisode";
+import { Episode, EpisodeType } from "./episodes";
 import React from "react";
 import { Scene } from "./scene";
 
@@ -32,18 +29,9 @@ export function generateDoubleEviction(initialGamestate: GameState): Episode {
         })
     );
 
-    const content = (
-        <HasText>
-            <Tabs />
-            <WeekStartWrapper gameState={initialGamestate} />
-            <br />
-            <NextEpisodeButton />
-        </HasText>
-    );
     const gameState = new GameState(currentGameState);
     return new Episode({
         gameState,
-        content,
         title: episode.title,
         scenes,
         type: DoubleEviction,

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -2,11 +2,12 @@ import React from "react";
 import { GameState } from "../../model/gameState";
 import { Scene } from "./scene";
 import { ViewsBar } from "../viewsBar/viewBar";
+import { defaultContent } from "./bigBrotherEpisode";
 
 export interface InitEpisode {
     scenes: Scene[];
     title: string;
-    content: JSX.Element;
+    content?: JSX.Element;
     gameState: GameState;
     initialGamestate?: GameState;
     type: EpisodeType;
@@ -33,7 +34,7 @@ export class Episode {
     constructor(init: InitEpisode) {
         this.scenes = init.scenes;
         this.title = init.title;
-        this.content = init.content;
+        this.content = init.content || defaultContent(init.initialGamestate || init.gameState);
         this.gameState = init.gameState;
         this.initialGameState = init.initialGamestate || init.gameState;
         this.type = init.type;

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { GameState } from "../../model/gameState";
-import { Scene } from "./scene";
+import { Scene } from "./scenes/scene";
 import { ViewsBar } from "../viewsBar/viewBar";
 import { defaultContent } from "./bigBrotherEpisode";
 

--- a/src/components/episode/gameOver.tsx
+++ b/src/components/episode/gameOver.tsx
@@ -1,5 +1,5 @@
 import { Episode, InitEpisode, EpisodeType } from "./episodes";
-import { Scene } from "./scene";
+import { Scene } from "./scenes/scene";
 import { GameState } from "../../model";
 import { generateVotingTable } from "./scenes/votingTable";
 import { evictHouseguest } from "./utilities/evictHouseguest";

--- a/src/components/episode/gameOver.tsx
+++ b/src/components/episode/gameOver.tsx
@@ -1,4 +1,4 @@
-import { Episode, InitEpisode, EpisodeType } from "./episodes";
+import { Episode, EpisodeType } from "./episodes";
 import { Scene } from "./scenes/scene";
 import { GameState } from "../../model";
 import { generateVotingTable } from "./scenes/votingTable";

--- a/src/components/episode/gameOver.tsx
+++ b/src/components/episode/gameOver.tsx
@@ -13,27 +13,12 @@ export const GameOver: EpisodeType = {
     generate: generateGameOver,
 };
 
-export function generateGameOver(gameState: GameState): GameOverEpisode {
+export function generateGameOver(gameState: GameState): Episode {
     const title = "Game Over";
     const scenes: Scene[] = [];
     const content = generateVotingTable(gameState);
     gameState.houseguests.forEach((hg) => {
         evictHouseguest(gameState, hg.id);
     });
-    return new GameOverEpisode({ gameState, content, title, scenes, type: GameOver });
-}
-
-export class GameOverEpisode extends Episode {
-    readonly title: string;
-    readonly scenes: Scene[];
-    readonly content: JSX.Element;
-    readonly gameState: GameState;
-
-    public constructor(init: InitEpisode) {
-        super(init);
-        this.title = init.title;
-        this.scenes = init.scenes;
-        this.content = init.content;
-        this.gameState = init.gameState;
-    }
+    return new Episode({ gameState, content, title, scenes, type: GameOver });
 }

--- a/src/components/episode/safetyChain.tsx
+++ b/src/components/episode/safetyChain.tsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { GameState } from "../../model";
 import { Episode, EpisodeType } from "./episodes";
-import { Scene } from "./scene";
+import { Scene } from "./scenes/scene";
 import { generateSafetyChainScene } from "./scenes/safetyChainScene";
 
 export const SafetyChain: EpisodeType = {

--- a/src/components/episode/safetyChain.tsx
+++ b/src/components/episode/safetyChain.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { GameState } from "../../model";
-import { HasText } from "../layout/text";
-import { NextEpisodeButton } from "../nextEpisodeButton/nextEpisodeButton";
-import { Tabs } from "./bigBrotherEpisode";
-import { WeekStartWrapper } from "./bigBrotherWeekstartWrapper";
-import { Episode, EpisodeType, InitEpisode } from "./episodes";
+import { Episode, EpisodeType } from "./episodes";
 import { Scene } from "./scene";
 import { generateSafetyChainScene } from "./scenes/safetyChainScene";
 
@@ -18,18 +14,11 @@ export const SafetyChain: EpisodeType = {
 };
 
 export function generateSafetyChain(initialGameState: GameState): Episode {
-    const content = (
-        <HasText>
-            <Tabs />
-            <WeekStartWrapper gameState={initialGameState} />
-            <NextEpisodeButton />
-        </HasText>
-    );
     let currentGameState: GameState = initialGameState;
     const title = `Safety Chain ${currentGameState.phase}`;
     const scenes: Scene[] = [];
     let safetyChainScene;
     [currentGameState, safetyChainScene] = generateSafetyChainScene(initialGameState);
     scenes.push(safetyChainScene);
-    return new Episode({ gameState: currentGameState, content, title, scenes, type: SafetyChain });
+    return new Episode({ gameState: currentGameState, title, scenes, type: SafetyChain });
 }

--- a/src/components/episode/safetyChain.tsx
+++ b/src/components/episode/safetyChain.tsx
@@ -17,7 +17,7 @@ export const SafetyChain: EpisodeType = {
     generate: generateSafetyChain,
 };
 
-export function generateSafetyChain(initialGameState: GameState): SafetyChainEpisode {
+export function generateSafetyChain(initialGameState: GameState): Episode {
     const content = (
         <HasText>
             <Tabs />
@@ -31,21 +31,5 @@ export function generateSafetyChain(initialGameState: GameState): SafetyChainEpi
     let safetyChainScene;
     [currentGameState, safetyChainScene] = generateSafetyChainScene(initialGameState);
     scenes.push(safetyChainScene);
-    return new SafetyChainEpisode({ gameState: currentGameState, content, title, scenes, type: SafetyChain });
-}
-
-export class SafetyChainEpisode extends Episode {
-    readonly title: string;
-    readonly scenes: Scene[];
-    readonly content: JSX.Element;
-    readonly gameState: GameState;
-    readonly type = SafetyChain;
-
-    public constructor(init: InitEpisode) {
-        super(init);
-        this.title = init.title;
-        this.scenes = init.scenes;
-        this.content = init.content;
-        this.gameState = init.gameState;
-    }
+    return new Episode({ gameState: currentGameState, content, title, scenes, type: SafetyChain });
 }

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -67,13 +67,13 @@ export function generateEvictionScene(
     let tieBreaker = { decision: -1, reason: "Error you should not be seeing this" };
     if (tieVote) {
         newGameState.currentLog.outOf++;
-        // TODO: this is returning a vote to EVICT when they're saving
         tieBreaker = castVote(
             HoH,
             pluralities.map((p) => nominees[p]),
             newGameState
         );
-        newGameState.currentLog.votes[HoH.id] = new HoHVote(nominees[tieBreaker.decision].id);
+
+        newGameState.currentLog.votes[HoH.id] = new HoHVote(nominees[pluralities[tieBreaker.decision]].id);
     }
     let evictees: Houseguest[] = [];
 
@@ -81,8 +81,8 @@ export function generateEvictionScene(
         // voting to evict
         if (tieBreaker.decision > -1) {
             // there was a tie
-            evictees.push(nominees[tieBreaker.decision]);
-            newGameState.currentLog.votesInMajority = voteCounts[tieBreaker.decision] + 1;
+            evictees.push(nominees[pluralities[tieBreaker.decision]]);
+            newGameState.currentLog.votesInMajority = voteCounts[pluralities[tieBreaker.decision]] + 1;
         } else {
             // there wasn't a tie
             evictees.push(nominees[pluralities[0]]);
@@ -92,8 +92,8 @@ export function generateEvictionScene(
         // voting to save
         if (tieBreaker.decision > -1) {
             // there was a tie
-            const safe = nominees[tieBreaker.decision];
-            newGameState.currentLog.votesInMajority = voteCounts[tieBreaker.decision] + 1;
+            const safe = nominees[pluralities[tieBreaker.decision]];
+            newGameState.currentLog.votesInMajority = voteCounts[pluralities[tieBreaker.decision]] + 1;
             nominees.forEach((nom) => {
                 if (nom.id !== safe.id) {
                     evictees.push(nom);
@@ -147,7 +147,7 @@ export function generateEvictionScene(
                         <Portraits houseguests={[displayHoH]} centered={true} />
                         <CenteredBold>
                             I vote to {options.votingTo.toLowerCase()}
-                            {` ${nominees[tieBreaker.decision].name}.`}
+                            {` ${nominees[pluralities[tieBreaker.decision]].name}.`}
                         </CenteredBold>
                     </div>
                 )}

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -11,6 +11,12 @@ import { DividerBox } from "../../layout/box";
 import { NomineeVote, NormalVote, HoHVote } from "../../../model/logging/voteType";
 import { evictHouseguest } from "../utilities/evictHouseguest";
 
+// TODO: use these
+interface EvictionSceneOptions {
+    votingTo: "Save" | "Evict";
+    doubleEviction: boolean;
+}
+
 export function generateEvictionScene(
     initialGameState: GameState,
     HoH: Houseguest,
@@ -89,13 +95,7 @@ export function generateEvictionScene(
                         <CenteredBold>I vote to evict {`${evictee.name}.`}</CenteredBold>
                     </div>
                 )}
-                <Portraits
-                    houseguests={[
-                        getById(newGameState, nominees[0].id),
-                        getById(newGameState, nominees[1].id),
-                    ]}
-                    centered={true}
-                />
+                <Portraits houseguests={nominees.map((hg) => getById(newGameState, hg.id))} centered={true} />
                 <CenteredBold>{`${evictee.name}... you have been evicted from the Big Brother House.`}</CenteredBold>
                 <NextEpisodeButton />
             </div>

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -155,7 +155,7 @@ export function generateEvictionScene(
                         nominees.filter((nom) => !evicteesSet.has(nom.id)).map((hg) => hg.name)
                     )}... you are safe.`}</CenteredBold>
                 )}
-                <CenteredBold>{`${options.votingTo === "Save" && "That means "}${listNames(
+                <CenteredBold>{`${options.votingTo === "Save" ? "That means " : ""}${listNames(
                     evictees.map((hg) => hg.name)
                 )}... you have been evicted from the Big Brother House.`}</CenteredBold>
                 <NextEpisodeButton />

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -8,7 +8,7 @@ import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
 import { CenteredBold, Centered } from "../../layout/centered";
 import { DividerBox } from "../../layout/box";
-import { NomineeVote, NormalVote, HoHVote } from "../../../model/logging/voteType";
+import { NomineeVote, NormalVote, HoHVote, SaveVote } from "../../../model/logging/voteType";
 import { evictHouseguest } from "../utilities/evictHouseguest";
 import { listNames, listVotes } from "../../../utils/listStrings";
 
@@ -50,7 +50,10 @@ export function generateEvictionScene(
             const logic = castVote(hg, nominees, newGameState);
             const result: ProfileHouseguest = { ...hg };
             result.tooltip = logic.reason;
-            newGameState.currentLog.votes[hg.id] = new NormalVote(nominees[logic.decision].id);
+            newGameState.currentLog.votes[hg.id] =
+                options.votingTo === "Evict"
+                    ? new NormalVote(nominees[logic.decision].id)
+                    : new SaveVote(nominees[logic.decision].id);
             votes[logic.decision].push(result);
             lastVoter = hg;
             outOf++;

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -12,7 +12,6 @@ import { NomineeVote, NormalVote, HoHVote } from "../../../model/logging/voteTyp
 import { evictHouseguest } from "../utilities/evictHouseguest";
 import { listNames, listVotes } from "../../../utils/listStrings";
 
-// a function that takes in an array of numbers and returns the indicies of all the numbers tied for the highest number
 function getHighestIndicies(numbers: number[]): number[] {
     const highest = Math.max(...numbers);
     const highestIndicies = numbers.reduce((acc: any[], cur, i) => {
@@ -64,7 +63,7 @@ export function generateEvictionScene(
         newGameState.currentLog.soleVoter = lastVoter!!.name;
     }
     let tieVote = pluralities.length > 1;
-    let tieBreaker = { decision: -1, reason: "Error you should not be seeing this" };
+    let tieBreaker = { decision: -1, reason: "" };
     if (tieVote) {
         newGameState.currentLog.outOf++;
         tieBreaker = castVote(

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -141,7 +141,9 @@ export function generateEvictionScene(
                 {tieVote && (
                     <div>
                         <CenteredBold> We have a tie.</CenteredBold>
-                        <Centered>{`${HoH.name}, as current Head of Household, you must cast the sole vote to evict.`}</Centered>
+                        <Centered>{`${
+                            HoH.name
+                        }, as current Head of Household, you must cast the sole vote to ${options.votingTo.toLowerCase()}.`}</Centered>
                         <Portraits houseguests={[displayHoH]} centered={true} />
                         <CenteredBold>
                             I vote to {options.votingTo.toLowerCase()}

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -80,12 +80,11 @@ export function generateEvictionScene(
             <div style={margin}>
                 <CenteredBold>{voteCountText}</CenteredBold>
                 <div className="columns is-centered">
-                    <DividerBox className="column">
-                        <Portraits houseguests={votes[0]} centered={true} />
-                    </DividerBox>
-                    <DividerBox className="column">
-                        <Portraits houseguests={votes[1]} centered={true} />
-                    </DividerBox>
+                    {votes.map((voters, i) => (
+                        <DividerBox className="column" key={`voters${i}`}>
+                            <Portraits houseguests={voters} centered={true} />
+                        </DividerBox>
+                    ))}
                 </div>
                 {tieVote && (
                     <div>

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -1,5 +1,5 @@
 import { GameState, Houseguest, MutableGameState, nonEvictedHouseguests, getById } from "../../../model";
-import { Scene } from "../scene";
+import { Scene } from "./scene";
 import { shuffle } from "lodash";
 import { ProfileHouseguest } from "../../memoryWall";
 import { castEvictionVote } from "../../../utils/ai/aiApi";

--- a/src/components/episode/scenes/finalEvictionScene.tsx
+++ b/src/components/episode/scenes/finalEvictionScene.tsx
@@ -1,5 +1,5 @@
 import { GameState, Houseguest, MutableGameState, nonEvictedHouseguests } from "../../../model";
-import { Scene } from "../scene";
+import { Scene } from "./scene";
 import { castEvictionVote } from "../../../utils/ai/aiApi";
 import { ProfileHouseguest } from "../../memoryWall";
 import { Portrait, Portraits } from "../../playerPortrait/portraits";

--- a/src/components/episode/scenes/finalHohCompScene.tsx
+++ b/src/components/episode/scenes/finalHohCompScene.tsx
@@ -4,9 +4,9 @@ import {
     MutableGameState,
     nonEvictedHouseguests,
     randomPlayer,
-    getById
+    getById,
 } from "../../../model";
-import { Scene } from "../scene";
+import { Scene } from "./scene";
 import { Portraits, Portrait } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
@@ -16,7 +16,7 @@ export function finalHohCompScene(initialGameState: GameState): [GameState, Scen
     const newGameState = new MutableGameState(initialGameState);
     const final3 = nonEvictedHouseguests(initialGameState);
     const enduranceWinner = randomPlayer(final3);
-    const enduranceLosers = final3.filter(hg => hg.id !== enduranceWinner.id);
+    const enduranceLosers = final3.filter((hg) => hg.id !== enduranceWinner.id);
     const skillWinner = randomPlayer(final3, [enduranceWinner]);
     const finalHoH = getById(newGameState, randomPlayer([enduranceWinner, skillWinner]).id);
     finalHoH.hohWins++;
@@ -41,7 +41,7 @@ export function finalHohCompScene(initialGameState: GameState): [GameState, Scen
                 <CenteredBold>{`Congratulations ${finalHoH.name}, you are the final Head of Household!`}</CenteredBold>
                 <NextEpisodeButton />
             </div>
-        )
+        ),
     });
     return [new GameState(newGameState), scene, finalHoH];
 }

--- a/src/components/episode/scenes/hohCompScene.tsx
+++ b/src/components/episode/scenes/hohCompScene.tsx
@@ -1,5 +1,5 @@
 import { GameState, Houseguest, MutableGameState, randomPlayer } from "../../../model";
-import { Scene } from "../scene";
+import { Scene } from "./scene";
 import { Portrait } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";

--- a/src/components/episode/scenes/hohCompScene.tsx
+++ b/src/components/episode/scenes/hohCompScene.tsx
@@ -25,7 +25,8 @@ export function generateHohCompScene(
                 {previousHoh.length > 0 &&
                     (doubleEviction ? (
                         <CenteredBold>
-                            Houseguests, please return to the living room. Tonight will be a double eviction.
+                            Houseguests, please return to the living room. Tonight will be a{" "}
+                            {initialGameState.__logindex__ === 1 ? "double" : "triple"} eviction.
                         </CenteredBold>
                     ) : (
                         <Centered>

--- a/src/components/episode/scenes/hohCompScene.tsx
+++ b/src/components/episode/scenes/hohCompScene.tsx
@@ -6,12 +6,17 @@ import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
 import { HoHVote } from "../../../model/logging/voteType";
 
+interface HohCompOptions {
+    doubleEviction: boolean;
+    customText?: string;
+}
+
 export function generateHohCompScene(
     initialGameState: GameState,
-    doubleEviction: boolean = false
+    options: HohCompOptions
 ): [GameState, Scene, Houseguest] {
     const newGameState = new MutableGameState(initialGameState);
-
+    const doubleEviction = options.doubleEviction;
     const previousHoh = initialGameState.previousHOH ? [initialGameState.previousHOH] : [];
     const newHoH: Houseguest = randomPlayer(newGameState.houseguests, previousHoh);
     newGameState.previousHOH = newHoH;
@@ -22,7 +27,10 @@ export function generateHohCompScene(
         gameState: initialGameState,
         content: (
             <div>
-                {previousHoh.length > 0 &&
+                {options.customText ? (
+                    <CenteredBold>{options.customText}</CenteredBold>
+                ) : (
+                    previousHoh.length > 0 &&
                     (doubleEviction ? (
                         <CenteredBold>
                             Houseguests, please return to the living room. Tonight will be a{" "}
@@ -32,7 +40,8 @@ export function generateHohCompScene(
                         <Centered>
                             {`Houseguests, it's time to find a new Head of Household. As outgoing HoH, ${previousHoh[0].name} will not compete.`}
                         </Centered>
-                    ))}
+                    ))
+                )}
                 <Portrait centered={true} houseguest={newHoH} />
                 <CenteredBold>{newHoH.name} has won Head of Household!</CenteredBold>
                 <br />

--- a/src/components/episode/scenes/juryVoteScene.tsx
+++ b/src/components/episode/scenes/juryVoteScene.tsx
@@ -1,5 +1,5 @@
 import { GameState, getJurors, nonEvictedHouseguests, MutableGameState, Houseguest } from "../../../model";
-import { Scene } from "../scene";
+import { Scene } from "./scene";
 import { castJuryVote } from "../../../utils/ai/aiApi";
 import { Portraits } from "../../playerPortrait/portraits";
 import React from "react";
@@ -14,7 +14,7 @@ export function juryVoteScene(initialGameState: GameState): [GameState, Scene] {
     const jurors: Houseguest[] = getJurors(newGameState);
     const finalists = nonEvictedHouseguests(newGameState);
     const votes: Array<ProfileHouseguest[]> = [[], []];
-    jurors.forEach(juror => {
+    jurors.forEach((juror) => {
         const decision = castJuryVote(juror, finalists);
         const result: ProfileHouseguest = { ...juror };
         votes[decision].push(result);
@@ -49,7 +49,7 @@ export function juryVoteScene(initialGameState: GameState): [GameState, Scene] {
                 <CenteredBold>{`Congratulations, ${winner.name}... you are the winner of Big Brother!`}</CenteredBold>
                 <NextEpisodeButton />
             </div>
-        )
+        ),
     });
     return [newGameState, scene];
 }

--- a/src/components/episode/scenes/nomCeremonyScene.tsx
+++ b/src/components/episode/scenes/nomCeremonyScene.tsx
@@ -32,7 +32,11 @@ export function generateNomCeremonyScene(
                 .decision
         );
         nom3.nominations++;
+        newGameState.currentLog.nominationsPreVeto.push(nom3.name);
     }
+    newGameState.currentLog.nominationsPreVeto = require("alphanum-sort")(
+        newGameState.currentLog.nominationsPreVeto
+    );
     const noms = nom3 ? shuffle([nom1, nom2, nom3]) : shuffle([nom1, nom2]);
     const finalStatement = options.thirdNominee
         ? `I have nominated you, ${noms[0].name}, ${noms[1].name}, and ${noms[2].name} for eviction. `

--- a/src/components/episode/scenes/nomCeremonyScene.tsx
+++ b/src/components/episode/scenes/nomCeremonyScene.tsx
@@ -1,5 +1,5 @@
 import { GameState, Houseguest, MutableGameState, getById } from "../../../model";
-import { Scene } from "../scene";
+import { Scene } from "./scene";
 import { shuffle } from "lodash";
 import { Portrait } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";

--- a/src/components/episode/scenes/safetyChainScene.tsx
+++ b/src/components/episode/scenes/safetyChainScene.tsx
@@ -5,7 +5,7 @@ import { getBestFriend } from "../../../utils/ai/aiUtils";
 import { Centered } from "../../layout/centered";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import { Portrait, Portraits } from "../../playerPortrait/portraits";
-import { Scene } from "../scene";
+import { Scene } from "./scene";
 import { evictHouseguest } from "../utilities/evictHouseguest";
 
 export function generateSafetyChainScene(initialGameState: GameState): [GameState, Scene] {

--- a/src/components/episode/scenes/scene.tsx
+++ b/src/components/episode/scenes/scene.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { GameState } from "../../model/gameState";
-import { ViewsBar } from "../viewsBar/viewBar";
+import { GameState } from "../../../model/gameState";
+import { ViewsBar } from "../../viewsBar/viewBar";
 interface InitScene {
     readonly title: string;
     readonly gameState: GameState;

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -1,5 +1,5 @@
 import { GameState, Houseguest, getById, exclude } from "../../../model";
-import { Scene } from "../scene";
+import { Scene } from "./scene";
 import { useGoldenVeto, backdoorNPlayers } from "../../../utils/ai/aiApi";
 import { Portrait } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -6,11 +6,11 @@ import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
 import { DividerBox } from "../../layout/box";
-import { listNames } from "../../../utils/names";
+import { listNames } from "../../../utils/listStrings";
 
 interface VetoCeremonyOptions {
     doubleEviction: boolean;
-    finalNominees: number; // TODO: this does nothing
+    finalNominees: number; // TODO: this does nothing, replace with nameReplacement? / forceUse? idk.
 }
 
 export function generateVetoCeremonyScene(

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
 import { DividerBox } from "../../layout/box";
 import { listNames } from "../../../utils/listStrings";
+import _ from "lodash";
 
 interface VetoCeremonyOptions {
     doubleEviction: boolean;
@@ -105,6 +106,8 @@ export function generateVetoCeremonyScene(
             </div>
         ),
     });
-    initialGameState.currentLog.nominationsPostVeto = [finalNominees[0].name, finalNominees[1].name];
+    initialGameState.currentLog.nominationsPostVeto = require("alphanum-sort")(
+        finalNominees.map((nom) => nom.name)
+    );
     return [initialGameState, scene, finalNominees];
 }

--- a/src/components/episode/scenes/vetoCompScene.tsx
+++ b/src/components/episode/scenes/vetoCompScene.tsx
@@ -6,7 +6,7 @@ import {
     randomPlayer,
     getById,
 } from "../../../model";
-import { Scene } from "../scene";
+import { Scene } from "./scene";
 import { Portraits } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";

--- a/src/components/episode/scenes/vetoCompScene.tsx
+++ b/src/components/episode/scenes/vetoCompScene.tsx
@@ -11,7 +11,7 @@ import { Portraits } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
-import { listNames } from "../../../utils/names";
+import { listNames } from "../../../utils/listStrings";
 
 export function generateVetoCompScene(
     initialGameState: GameState,

--- a/src/components/episode/scenes/vetoCompScene.tsx
+++ b/src/components/episode/scenes/vetoCompScene.tsx
@@ -11,12 +11,12 @@ import { Portraits } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
+import { listNames } from "../../../utils/names";
 
 export function generateVetoCompScene(
     initialGameState: GameState,
     HoH: Houseguest,
-    nom1: Houseguest,
-    nom2: Houseguest,
+    nominees: Houseguest[],
     doubleEviction: boolean = false
 ): [GameState, Scene, Houseguest] {
     const newGameState = new MutableGameState(initialGameState);
@@ -28,18 +28,16 @@ export function generateVetoCompScene(
 
     if (everyoneWillPlay) {
         povPlayers.push({ ...HoH });
-        povPlayers.push({ ...nom1 });
-        povPlayers.push({ ...nom2 });
+        nominees.forEach((nominee) => povPlayers.push({ ...nominee }));
         while (povPlayers.length < choices.length) {
             povPlayers.push({ ...randomPlayer(choices, povPlayers) });
         }
     } else {
         povPlayers.push({ ...HoH });
-        povPlayers.push({ ...nom1 });
-        povPlayers.push({ ...nom2 });
-        povPlayers.push({ ...randomPlayer(choices, povPlayers) });
-        povPlayers.push({ ...randomPlayer(choices, povPlayers) });
-        povPlayers.push({ ...randomPlayer(choices, povPlayers) });
+        nominees.forEach((nominee) => povPlayers.push({ ...nominee }));
+        while (povPlayers.length < 6) {
+            povPlayers.push({ ...randomPlayer(choices, povPlayers) });
+        }
     }
     let povWinner = randomPlayer(povPlayers);
     povWinner = getById(newGameState, povWinner.id);
@@ -49,9 +47,13 @@ export function generateVetoCompScene(
     if (everyoneWillPlay) {
         introText = "Everyone left in the house will compete in this challenge.";
     } else {
-        introText = `${HoH.name}, as Head of Household, and ${nom1.name} and ${nom2.name} as nominees, will compete, as well as 3 others chosen by random draw.`;
+        introText = `${HoH.name}, as Head of Household, and ${listNames(
+            nominees.map((nom) => nom.name)
+        )} as nominees, will compete, as well as ${6 - 1 - nominees.length} others chosen by random draw.`; // this line assumes hoh plays in veto (-1)
     }
-    const extras = [povPlayers[3]];
+    const extras = nominees[2] ? [] : [povPlayers[3]];
+    const firstRow = [povPlayers[0], povPlayers[1], povPlayers[2]];
+    nominees[2] && firstRow.push(povPlayers[3]);
     povPlayers[4] && extras.push(povPlayers[4]);
     povPlayers[5] && extras.push(povPlayers[5]);
     const scene = new Scene({
@@ -64,7 +66,7 @@ export function generateVetoCompScene(
                         ? "The houseguests compete in the veto competition."
                         : "It's time to pick players for the veto competition."}
                 </Centered>
-                <Portraits centered={true} houseguests={[HoH, nom1, nom2]} />
+                <Portraits centered={true} houseguests={firstRow} />
                 {!doubleEviction && <Centered>{introText}</Centered>}
                 <Portraits centered={true} houseguests={extras} />
                 <Centered>...</Centered>

--- a/src/components/episode/scenes/votingTable.tsx
+++ b/src/components/episode/scenes/votingTable.tsx
@@ -6,6 +6,7 @@ import { GameState, getById } from "../../../model";
 import { VoteType, WinnerVote, RunnerUpVote } from "../../../model/logging/voteType";
 import { FullscreenButton } from "../../mainPage/fullscreenButton";
 import { ColorTheme } from "../../../theme/theme";
+import _ from "lodash";
 
 export const EndgameTableCell = styled.td`
     padding: 0.1em 0.4em;
@@ -196,17 +197,20 @@ function generateEvictedRow(
         );
         return;
     }
-
-    const voteTextLine1 =
-        log.soleVoter !== undefined
-            ? `${log.soleVoter}'s choice`
-            : `${log.votesInMajority} of ${log.outOf} votes`;
-
     const saveOrEvict =
         log.soleVoter !== undefined ? "evict" : (log.votingTo && log.votingTo.toLowerCase()) || "evict";
 
     const rowSpan = log.evicted.length === 1 ? 2 : 1;
     log.evicted.forEach((evicted, i) => {
+        const voteTextLine1 =
+            log.soleVoter !== undefined
+                ? `${log.soleVoter}'s choice`
+                : `${
+                      log.votingTo === "Save"
+                          ? Object.values(log.votes).filter((vote) => vote.id === evicted).length
+                          : log.votesInMajority
+                  } of ${log.outOf} votes`;
+
         const content = (
             <Evicted key={`evicted${i}--${anotherKey++}`} rowSpan={rowSpan}>
                 <Centered noMargin={true}>

--- a/src/components/episode/scenes/votingTable.tsx
+++ b/src/components/episode/scenes/votingTable.tsx
@@ -133,21 +133,23 @@ export function generateVotingTable(gameState: GameState): JSX.Element {
     );
     const houseguestRows: JSX.Element[] = [];
     const evictedRow = <tr>{evictedCells}</tr>;
-    let evictionColSpan = -1;
+    let desiredLength = -1;
     evictionOrder.reverse().forEach(([id, week], i) => {
-        if (evictionColSpan > 0) {
+        if (i === 0) desiredLength = houseguestCells[id].length;
+        if (i > 1) {
             const weekText = i === 2 ? "(Finale)" : `(Week ${week})`;
-            const isJury = getById(gameState, id).isJury;
-            const colSpan = isJury ? evictionColSpan - 1 : evictionColSpan;
             const evicted = (
-                <Evicted colSpan={colSpan} key={`evicted-week-${weekText}-${i}`}>
+                <Evicted
+                    colSpan={desiredLength - houseguestCells[id].length}
+                    key={`evicted-week-${weekText}-${i}`}
+                >
                     <CenteredItallic noMargin={true}>Evicted</CenteredItallic>
                     <CenteredItallic noMargin={true}>
                         <small>{weekText}</small>
                     </CenteredItallic>
                 </Evicted>
             );
-            if (!isJury) {
+            if (!getById(gameState, id).isJury) {
                 houseguestCells[id].push(evicted); // not jury, they dead
             } else {
                 const tempList = houseguestCells[id].slice(0, -1);
@@ -157,7 +159,6 @@ export function generateVotingTable(gameState: GameState): JSX.Element {
             }
         }
         houseguestRows.push(<tr key={`hgrow--${id}--${anotherKey++}`}>{houseguestCells[id]}</tr>);
-        evictionColSpan++;
     });
 
     return (

--- a/src/components/episode/scenes/votingTable.tsx
+++ b/src/components/episode/scenes/votingTable.tsx
@@ -81,9 +81,10 @@ export function generateVotingTable(gameState: GameState): JSX.Element {
             generatePreVetoRow(log, i, preVetoCells);
             generateVetoRow(log, i, vetoCells);
             generatePostVetoRow(log, i, postVetoCells);
-            generateEvictedRow(log, i, evictedCells, gameState);
+            generateEvictedRow(log, i, evictedCells, winnerCells, gameState);
             if (!log) return;
-            evictionOrder.push([log.evicted, i]);
+            log.evicted.forEach((evicted) => evictionOrder.push([evicted, i]));
+
             if (log.runnerUp !== undefined) evictionOrder.push([log.runnerUp, i]);
             if (log.winner !== undefined) evictionOrder.push([log.winner, i]);
             // add each of the votes to the houseguest cells
@@ -183,6 +184,7 @@ function generateEvictedRow(
     log: EpisodeLog | undefined,
     i: number,
     cells: JSX.Element[],
+    winnerCells: JSX.Element[],
     gameState: GameState
 ) {
     if (!log) {
@@ -199,18 +201,23 @@ function generateEvictedRow(
             ? `${log.soleVoter}'s choice`
             : `${log.votesInMajority} of ${log.outOf} votes`;
 
-    cells.push(
-        <Evicted key={`evicted${i}--${anotherKey++}`} rowSpan={2}>
-            <Centered noMargin={true}>
-                <b>{getById(gameState, log.evicted).name}</b>
-                <br />
-                <small>
-                    {voteTextLine1} <br />
-                    to evict
-                </small>
-            </Centered>
-        </Evicted>
-    );
+    const rowSpan = log.evicted.length === 1 ? 2 : 1;
+    log.evicted.forEach((evicted, i) => {
+        const content = (
+            <Evicted key={`evicted${i}--${anotherKey++}`} rowSpan={rowSpan}>
+                <Centered noMargin={true}>
+                    <b>{getById(gameState, evicted).name}</b>
+                    <br />
+                    <small>
+                        {voteTextLine1} <br />
+                        to {(log.votingTo && log.votingTo.toLowerCase()) || "evict"}
+                    </small>
+                </Centered>
+            </Evicted>
+        );
+        if (i === 0) cells.push(content);
+        else winnerCells.push(content);
+    });
 }
 
 function generatePostVetoRow(log: EpisodeLog | undefined, i: number, cells: JSX.Element[]) {

--- a/src/components/episode/scenes/votingTable.tsx
+++ b/src/components/episode/scenes/votingTable.tsx
@@ -22,6 +22,10 @@ const Gray = styled(EndgameTableCell)`
     background-color: ${({ theme }: { theme: ColorTheme }) => theme.grayCell};
 `;
 
+export const SaveCell = styled(EndgameTableCell)`
+    background-color: ${({ theme }: { theme: ColorTheme }) => theme.saveCell};
+`;
+
 const White = styled(EndgameTableCell)`
     background-color: ${({ theme }: { theme: ColorTheme }) => theme.lightGrayCell};
 `;

--- a/src/components/episode/scenes/votingTable.tsx
+++ b/src/components/episode/scenes/votingTable.tsx
@@ -49,7 +49,7 @@ const BlackRow = styled.tr`
     height: 0.4em;
     background-color: #000000;
 `;
-
+let anotherKey = 0;
 export function generateVotingTable(gameState: GameState): JSX.Element {
     const masterLog: EpisodeLog[][] = gameState.log;
     const houseguestCells: JSX.Element[][] = [];
@@ -155,7 +155,7 @@ export function generateVotingTable(gameState: GameState): JSX.Element {
                 houseguestCells[id] = tempList;
             }
         }
-        houseguestRows.push(<tr key={`hgrow--${id}`}>{houseguestCells[id]}</tr>);
+        houseguestRows.push(<tr key={`hgrow--${id}--${anotherKey++}`}>{houseguestCells[id]}</tr>);
         evictionColSpan++;
     });
 
@@ -187,7 +187,7 @@ function generateEvictedRow(
 ) {
     if (!log) {
         cells.push(
-            <Gray key={i} rowSpan={2}>
+            <Gray key={`evicted${i}--${anotherKey++}`} rowSpan={2}>
                 <CenteredBold noMargin={true}>Evicted</CenteredBold>
             </Gray>
         );
@@ -200,7 +200,7 @@ function generateEvictedRow(
             : `${log.votesInMajority} of ${log.outOf} votes`;
 
     cells.push(
-        <Evicted key={i} rowSpan={2}>
+        <Evicted key={`evicted${i}--${anotherKey++}`} rowSpan={2}>
             <Centered noMargin={true}>
                 <b>{getById(gameState, log.evicted).name}</b>
                 <br />
@@ -216,7 +216,7 @@ function generateEvictedRow(
 function generatePostVetoRow(log: EpisodeLog | undefined, i: number, cells: JSX.Element[]) {
     if (!log) {
         cells.push(
-            <Gray key={`postVeto--${i}`}>
+            <Gray key={`postVeto--${i}-${anotherKey++}`}>
                 <CenteredBold noMargin={true}>
                     Nominations
                     <br />
@@ -227,10 +227,15 @@ function generatePostVetoRow(log: EpisodeLog | undefined, i: number, cells: JSX.
         return;
     }
     cells.push(
-        <White key={`postVeto--${i}`}>
+        <White key={`preveto--${i}-${anotherKey++}`}>
             <Centered noMargin={true}>
-                {log.nominationsPostVeto[0]}
-                <br /> {log.nominationsPostVeto[1]}
+                {interleave(
+                    log.nominationsPostVeto as any,
+                    (key) => (
+                        <br key={`preveto--br--${i}-${key++}`} />
+                    ),
+                    anotherKey
+                )}
             </Centered>
         </White>
     );
@@ -239,7 +244,7 @@ function generatePostVetoRow(log: EpisodeLog | undefined, i: number, cells: JSX.
 function generateVetoRow(log: EpisodeLog | undefined, i: number, cells: JSX.Element[]) {
     if (!log) {
         cells.push(
-            <Gray key={`veto--${i}`}>
+            <Gray key={`veto--${i}-${anotherKey++}`}>
                 <CenteredBold noMargin={true}>Veto Winner</CenteredBold>
             </Gray>
         );
@@ -248,16 +253,21 @@ function generateVetoRow(log: EpisodeLog | undefined, i: number, cells: JSX.Elem
     if (log.vetoWinner === undefined) return;
 
     cells.push(
-        <White key={`veto--${i}`}>
+        <White key={`veto--${i}-${anotherKey++}`}>
             <Centered noMargin={true}>{log.vetoWinner}</Centered>
         </White>
     );
 }
 
+// javascript is my passion
+function interleave<T>(arr: T[], thing: (key: number) => T, key: number): T[] {
+    return ([] as T[]).concat(...arr.map((n: T) => [n, thing(key++)])).slice(0, -1);
+}
+
 function generatePreVetoRow(log: EpisodeLog | undefined, i: number, cells: JSX.Element[]) {
     if (!log) {
         cells.push(
-            <Gray key={`preveto--${i}`}>
+            <Gray key={`preveto--${i}-${anotherKey++}`}>
                 <CenteredBold noMargin={true}>
                     Nominations
                     <br />
@@ -269,17 +279,22 @@ function generatePreVetoRow(log: EpisodeLog | undefined, i: number, cells: JSX.E
     }
     if (log.nominationsPreVeto.length === 0) {
         cells.push(
-            <White key={`preveto--${i}`} rowSpan={2}>
+            <White key={`preveto--${i}-${anotherKey++}`} rowSpan={2}>
                 <CenteredItallic noMargin={true}>(none)</CenteredItallic>
             </White>
         );
         return;
     }
     cells.push(
-        <White key={`preveto--${i}`}>
+        <White key={`preveto--${i}-${anotherKey++}`}>
             <Centered noMargin={true}>
-                {log.nominationsPreVeto[0]}
-                <br /> {log.nominationsPreVeto[1]}
+                {interleave(
+                    log.nominationsPreVeto as any,
+                    (key) => (
+                        <br key={`preveto--br--${i}-${key++}`} />
+                    ),
+                    anotherKey
+                )}
             </Centered>
         </White>
     );

--- a/src/components/episode/scenes/votingTable.tsx
+++ b/src/components/episode/scenes/votingTable.tsx
@@ -202,6 +202,9 @@ function generateEvictedRow(
             ? `${log.soleVoter}'s choice`
             : `${log.votesInMajority} of ${log.outOf} votes`;
 
+    const saveOrEvict =
+        log.soleVoter !== undefined ? "evict" : (log.votingTo && log.votingTo.toLowerCase()) || "evict";
+
     const rowSpan = log.evicted.length === 1 ? 2 : 1;
     log.evicted.forEach((evicted, i) => {
         const content = (
@@ -211,7 +214,7 @@ function generateEvictedRow(
                     <br />
                     <small>
                         {voteTextLine1} <br />
-                        to {(log.votingTo && log.votingTo.toLowerCase()) || "evict"}
+                        to {saveOrEvict}
                     </small>
                 </Centered>
             </Evicted>

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -24,6 +24,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
 
     return new Episode({
         gameState: new GameState(currentGameState),
+        initialGamestate,
         title: episode.title,
         scenes,
         type: TripleEvictionCad,

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -1,37 +1,30 @@
-import { GameState } from "../../model";
+import React from "react";
+import { Episode, EpisodeType, GameState } from "../../model";
 import { HasText } from "../layout/text";
 import { NextEpisodeButton } from "../nextEpisodeButton/nextEpisodeButton";
 import { generateBBVanillaScenes, Tabs } from "./bigBrotherEpisode";
 import { WeekStartWrapper } from "./bigBrotherWeekstartWrapper";
-import { Episode, EpisodeType, InitEpisode } from "./episodes";
-import React from "react";
 import { Scene } from "./scene";
 
-export const DoubleEviction: EpisodeType = {
-    canPlayWith: (n: number) => n >= 5,
-    eliminates: 2,
+export const TripleEvictionCad: EpisodeType = {
+    canPlayWith: (n: number) => n >= 6,
+    eliminates: 3,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "Double Eviction",
-    generate: generateDoubleEviction,
+    name: "Triple Eviction CAD",
+    generate: generateTripleEvictionCad,
 };
 
-export function generateDoubleEviction(initialGamestate: GameState): Episode {
+// TODO: we need to make it so they don't use triple eviction veto -___-
+
+export function generateTripleEvictionCad(initialGamestate: GameState): Episode {
     const episode = generateBBVanillaScenes(initialGamestate);
     let currentGameState = episode.gameState;
     const scenes: Scene[] = episode.scenes;
 
     currentGameState.incrementLogIndex();
-    const doubleEviction = generateBBVanillaScenes(currentGameState, true);
-    currentGameState = doubleEviction.gameState;
-    scenes.push(
-        new Scene({
-            title: "Double Eviction",
-            content: <div>{doubleEviction.scenes.map((scene) => scene.content)}</div>,
-            gameState: doubleEviction.gameState,
-        })
-    );
 
+    const gameState = new GameState(currentGameState);
     const content = (
         <HasText>
             <Tabs />
@@ -40,12 +33,11 @@ export function generateDoubleEviction(initialGamestate: GameState): Episode {
             <NextEpisodeButton />
         </HasText>
     );
-    const gameState = new GameState(currentGameState);
     return new Episode({
         gameState,
         content,
         title: episode.title,
         scenes,
-        type: DoubleEviction,
+        type: TripleEvictionCad,
     });
 }

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -1,7 +1,7 @@
-import React from "react";
 import { Episode, EpisodeType, GameState } from "../../model";
+import React from "react";
 import { generateBBVanillaScenes } from "./bigBrotherEpisode";
-import { Scene } from "./scene";
+import { Scene } from "./scenes/scene";
 
 export const TripleEvictionCad: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
@@ -20,7 +20,15 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
     const scenes: Scene[] = episode.scenes;
 
     currentGameState.incrementLogIndex();
-    // TODO: triple eviction stuff
+    const doubleEviction = generateBBVanillaScenes(currentGameState, true);
+    currentGameState = doubleEviction.gameState;
+    scenes.push(
+        new Scene({
+            title: "Double Eviction",
+            content: <div>{doubleEviction.scenes.map((scene) => scene.content)}</div>,
+            gameState: doubleEviction.gameState,
+        })
+    );
 
     return new Episode({
         gameState: new GameState(currentGameState),

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -1,7 +1,8 @@
-import { Episode, EpisodeType, GameState } from "../../model";
+import { Episode, EpisodeType, GameState, Houseguest } from "../../model";
 import React from "react";
 import { generateBBVanillaScenes } from "./bigBrotherEpisode";
 import { Scene } from "./scenes/scene";
+import { generateHohCompScene } from "./scenes/hohCompScene";
 
 export const TripleEvictionCad: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
@@ -18,13 +19,29 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
     const scenes: Scene[] = episode.scenes;
 
     currentGameState.incrementLogIndex();
-    const doubleEviction = generateBBVanillaScenes(currentGameState, true);
-    currentGameState = doubleEviction.gameState;
+
+    // hoh comp
+    let hoh: Houseguest;
+    let hohCompScene: Scene;
+    const tripleScenes: Scene[] = [];
+    [currentGameState, hohCompScene, hoh] = generateHohCompScene(currentGameState, {
+        doubleEviction: true,
+        customText: "Houseguests, please return to the living room. Tonight will be a triple eviction.",
+    }); // TODO: HoH comp scene options object
+    tripleScenes.push(hohCompScene);
+    // nominations, TODO: use backdoorNplayers function to find N nominees
+
+    // pov
+
+    // veto ceremony
+
+    // vote to SAVE
+
     scenes.push(
         new Scene({
-            title: "Double Eviction",
-            content: <div>{doubleEviction.scenes.map((scene) => scene.content)}</div>,
-            gameState: doubleEviction.gameState,
+            title: "Triple Eviction",
+            content: <div>{tripleScenes.map((scene) => scene.content)}</div>,
+            gameState: currentGameState,
         })
     );
 

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import { Episode, EpisodeType, GameState } from "../../model";
-import { HasText } from "../layout/text";
-import { NextEpisodeButton } from "../nextEpisodeButton/nextEpisodeButton";
-import { generateBBVanillaScenes, Tabs } from "./bigBrotherEpisode";
-import { WeekStartWrapper } from "./bigBrotherWeekstartWrapper";
+import { generateBBVanillaScenes } from "./bigBrotherEpisode";
 import { Scene } from "./scene";
 
 export const TripleEvictionCad: EpisodeType = {
@@ -11,7 +8,7 @@ export const TripleEvictionCad: EpisodeType = {
     eliminates: 3,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "Triple Eviction CAD",
+    name: "Triple Eviction CA",
     generate: generateTripleEvictionCad,
 };
 
@@ -23,19 +20,10 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
     const scenes: Scene[] = episode.scenes;
 
     currentGameState.incrementLogIndex();
+    // TODO: triple eviction stuff
 
-    const gameState = new GameState(currentGameState);
-    const content = (
-        <HasText>
-            <Tabs />
-            <WeekStartWrapper gameState={initialGamestate} />
-            <br />
-            <NextEpisodeButton />
-        </HasText>
-    );
     return new Episode({
-        gameState,
-        content,
+        gameState: new GameState(currentGameState),
         title: episode.title,
         scenes,
         type: TripleEvictionCad,

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -62,9 +62,11 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
     );
     tripleScenes.push(vetoCeremonyScene);
 
-    // vote to SAVE
     let evictionScene;
-    [currentGameState, evictionScene] = generateEvictionScene(currentGameState, hoh, nominees, true);
+    [currentGameState, evictionScene] = generateEvictionScene(currentGameState, hoh, nominees, {
+        doubleEviction: true,
+        votingTo: "Save",
+    });
     tripleScenes.push(evictionScene);
 
     scenes.push(

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -8,7 +8,7 @@ export const TripleEvictionCad: EpisodeType = {
     eliminates: 3,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "Triple Eviction CA",
+    name: "Triple Eviction 🇨🇦",
     generate: generateTripleEvictionCad,
 };
 

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -3,6 +3,9 @@ import React from "react";
 import { generateBBVanillaScenes } from "./bigBrotherEpisode";
 import { Scene } from "./scenes/scene";
 import { generateHohCompScene } from "./scenes/hohCompScene";
+import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
+import { generateVetoCompScene } from "./scenes/vetoCompScene";
+import { generateVetoCeremonyScene } from "./scenes/vetoCeremonyScene";
 
 export const TripleEvictionCad: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
@@ -20,20 +23,43 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
 
     currentGameState.incrementLogIndex();
 
-    // hoh comp
     let hoh: Houseguest;
     let hohCompScene: Scene;
     const tripleScenes: Scene[] = [];
     [currentGameState, hohCompScene, hoh] = generateHohCompScene(currentGameState, {
         doubleEviction: true,
         customText: "Houseguests, please return to the living room. Tonight will be a triple eviction.",
-    }); // TODO: HoH comp scene options object
+    });
     tripleScenes.push(hohCompScene);
-    // nominations, TODO: use backdoorNplayers function to find N nominees
 
-    // pov
+    let nomCeremonyScene;
+    let nominees: Houseguest[];
+    [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, hoh, {
+        doubleEviction: true,
+        thirdNominee: true,
+    });
+    tripleScenes.push(nomCeremonyScene);
 
-    // veto ceremony
+    let vetoCompScene;
+    let povWinner: Houseguest;
+    [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
+        currentGameState,
+        hoh,
+        nominees,
+        true
+    );
+    tripleScenes.push(vetoCompScene);
+
+    let vetoCeremonyScene;
+
+    [currentGameState, vetoCeremonyScene, nominees] = generateVetoCeremonyScene(
+        currentGameState,
+        hoh,
+        nominees,
+        povWinner,
+        { doubleEviction: true, finalNominees: 3 }
+    );
+    tripleScenes.push(vetoCeremonyScene);
 
     // vote to SAVE
 

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -6,6 +6,7 @@ import { generateHohCompScene } from "./scenes/hohCompScene";
 import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
 import { generateVetoCompScene } from "./scenes/vetoCompScene";
 import { generateVetoCeremonyScene } from "./scenes/vetoCeremonyScene";
+import { generateEvictionScene } from "./scenes/evictionScene";
 
 export const TripleEvictionCad: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
@@ -62,6 +63,9 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
     tripleScenes.push(vetoCeremonyScene);
 
     // vote to SAVE
+    let evictionScene;
+    [currentGameState, evictionScene] = generateEvictionScene(currentGameState, hoh, nominees, true);
+    tripleScenes.push(evictionScene);
 
     scenes.push(
         new Scene({

--- a/src/components/episode/tripleEvictionEpisodeUs.tsx
+++ b/src/components/episode/tripleEvictionEpisodeUs.tsx
@@ -3,16 +3,16 @@ import React from "react";
 import { generateBBVanillaScenes } from "./bigBrotherEpisode";
 import { Scene } from "./scenes/scene";
 
-export const TripleEvictionCad: EpisodeType = {
+export const TripleEvictionUs: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
     eliminates: 3,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "Triple Eviction 🇨🇦",
-    generate: generateTripleEvictionCad,
+    name: "Triple Eviction 🇺🇸",
+    generate: generateTripleEvictionUs,
 };
 
-export function generateTripleEvictionCad(initialGamestate: GameState): Episode {
+export function generateTripleEvictionUs(initialGamestate: GameState): Episode {
     const episode = generateBBVanillaScenes(initialGamestate);
     let currentGameState = episode.gameState;
     const scenes: Scene[] = episode.scenes;
@@ -27,12 +27,21 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
             gameState: doubleEviction.gameState,
         })
     );
-
+    currentGameState.incrementLogIndex();
+    const tripleEviction = generateBBVanillaScenes(currentGameState, true);
+    currentGameState = tripleEviction.gameState;
+    scenes.push(
+        new Scene({
+            title: "Triple Eviction",
+            content: <div>{tripleEviction.scenes.map((scene) => scene.content)}</div>,
+            gameState: tripleEviction.gameState,
+        })
+    );
     return new Episode({
         gameState: new GameState(currentGameState),
         initialGamestate,
         title: episode.title,
         scenes,
-        type: TripleEvictionCad,
+        type: TripleEvictionUs,
     });
 }

--- a/src/components/episode/utilities/evictHouseguest.ts
+++ b/src/components/episode/utilities/evictHouseguest.ts
@@ -17,7 +17,7 @@ import { Targets, getRelationshipSummary } from "../../../utils/ai/targets";
 
 export function evictHouseguest(gameState: MutableGameState, id: number): GameState {
     const evictee = getById(gameState, id);
-    if (gameState.currentLog) gameState.currentLog.evicted = evictee.id;
+    if (gameState.currentLog) gameState.currentLog.evicted.push(evictee.id);
     evictee.isEvicted = true;
     if (gameState.remainingPlayers - getFinalists() <= gameState.finalJurySize()) {
         evictee.isJury = true;

--- a/src/components/pregameScreen/pregameScreen.tsx
+++ b/src/components/pregameScreen/pregameScreen.tsx
@@ -19,13 +19,6 @@ export class PregameScreen extends React.Component<PregameScreenProps, {}> {
 
     public render() {
         const props = this.props;
-        if (props.cast.length === 0) {
-            return (
-                <HasText>
-                    Cast is empty. <ChooseCastLink />
-                </HasText>
-            );
-        }
         return (
             <HasText>
                 <h2
@@ -37,7 +30,7 @@ export class PregameScreen extends React.Component<PregameScreenProps, {}> {
                 >
                     Big Brother Bots
                 </h2>
-                <MemoryWall houseguests={props.cast} />
+                {props.cast.length === 0 ? "Loading..." : <MemoryWall houseguests={props.cast} />}
                 <p>
                     <b> {"You can use the <- and -> arrow keys to move forwards and backwards."}</b>
                 </p>

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -54,7 +54,6 @@ export function SeasonEditorPage(): JSX.Element {
             </div>
             <div className="column" style={{ padding: 20 }}>
                 <Subheader>Add Twists</Subheader>
-                <hr />
                 <div className="columns is-multiline is-centered">
                     {twists.map((type) => (
                         <TwistAdder type={type} key={type.name} />

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -59,31 +59,41 @@ export function SeasonEditorPage(): JSX.Element {
                     {twists.map((type) => (
                         <TwistAdder type={type} key={type.name} />
                     ))}
-                </div>
-                <HasText className="field is-horizontal centered">
-                    <div className="field-label is-normal">
-                        <Label className="label" style={validJurySize ? {} : { color: "#fb8a8a" }}>
-                            Jury Size:
-                        </Label>
-                    </div>
-                    <div className="field-body">
-                        <div className="field">
-                            <div className="control">
-                                <NumericInput
-                                    className={validJurySize ? undefined : "is-danger"}
-                                    value={jurySize}
-                                    onChange={setJurySize}
-                                    placeholder={`${defaultJurySize(castLength)}`}
-                                />
+                    <div
+                        className="column is-4"
+                        style={{
+                            border: "1px solid #808080",
+                            borderRadius: "4px",
+                            backgroundColor: "#444346",
+                            margin: "10px",
+                        }}
+                    >
+                        <HasText className="field is-horizontal centered">
+                            <div className="field-label is-normal">
+                                <Label className="label" style={validJurySize ? {} : { color: "#fb8a8a" }}>
+                                    Jury Size:
+                                </Label>
                             </div>
-                            <p className="help" style={validJurySize ? {} : { color: "#fb8a8a" }}>
-                                {validJurySize
-                                    ? `(Jury starts at F${parseInt(jurySize) + 2})`
-                                    : `Jury must be an odd number < ${castLength - 2}`}
-                            </p>
-                        </div>
+                            <div className="field-body">
+                                <div className="field">
+                                    <div className="control">
+                                        <NumericInput
+                                            className={validJurySize ? undefined : "is-danger"}
+                                            value={jurySize}
+                                            onChange={setJurySize}
+                                            placeholder={`${defaultJurySize(castLength)}`}
+                                        />
+                                    </div>
+                                    <p className="help" style={validJurySize ? {} : { color: "#fb8a8a" }}>
+                                        {validJurySize
+                                            ? `(Jury starts at F${parseInt(jurySize) + 2})`
+                                            : `Jury must be an odd number < ${castLength - 2}`}
+                                    </p>
+                                </div>
+                            </div>
+                        </HasText>
                     </div>
-                </HasText>
+                </div>
             </div>
             <div className="column is-narrow" style={{ padding: 40 }}>
                 <button

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -7,6 +7,7 @@ import { DoubleEviction } from "../episode/doubleEvictionEpisode";
 import { EpisodeType } from "../episode/episodes";
 import { PregameEpisode } from "../episode/pregameEpisode";
 import { TripleEvictionCad } from "../episode/tripleEvictionEpisodeCad";
+import { TripleEvictionUs } from "../episode/tripleEvictionEpisodeUs";
 import { HasText } from "../layout/text";
 import { selectPlayer } from "../playerPortrait/selectedPortrait";
 import { Noselect } from "../playerPortrait/setupPortrait";
@@ -23,7 +24,7 @@ export const Label = styled.label`
     color: #fff;
 `;
 
-const twists: EpisodeType[] = [DoubleEviction, TripleEvictionCad];
+const twists: EpisodeType[] = [DoubleEviction, TripleEvictionCad, TripleEvictionUs];
 
 const submit = async (jury: number): Promise<void> => {
     season$.next(getEpisodeLibrary());

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -6,6 +6,7 @@ import { NumericInput } from "../castingScreen/numericInput";
 import { DoubleEviction } from "../episode/doubleEvictionEpisode";
 import { EpisodeType } from "../episode/episodes";
 import { PregameEpisode } from "../episode/pregameEpisode";
+import { TripleEvictionCad } from "../episode/tripleEvictionEpisodeCad";
 import { HasText } from "../layout/text";
 import { selectPlayer } from "../playerPortrait/selectedPortrait";
 import { Noselect } from "../playerPortrait/setupPortrait";
@@ -22,7 +23,7 @@ export const Label = styled.label`
     color: #fff;
 `;
 
-const twists: EpisodeType[] = [DoubleEviction];
+const twists: EpisodeType[] = [DoubleEviction, TripleEvictionCad];
 
 const submit = async (jury: number): Promise<void> => {
     season$.next(getEpisodeLibrary());

--- a/src/components/seasonEditor/twistAdder.tsx
+++ b/src/components/seasonEditor/twistAdder.tsx
@@ -34,7 +34,15 @@ export class TwistAdder extends React.Component<
     public render(): JSX.Element {
         const twistCount = this.state.twistCount;
         return (
-            <div className="column is-narrow">
+            <div
+                className="column is-narrow"
+                style={{
+                    border: "1px solid #808080",
+                    borderRadius: "4px",
+                    backgroundColor: "#444346",
+                    margin: "10px",
+                }}
+            >
                 <div className="field has-addons has-addons-centered">
                     <p
                         className="field-label is-normal control"

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,15 +1,19 @@
 import React from "react";
 import { SidebarController } from "./sidebarController";
 import { PregameEpisode } from "../episode/pregameEpisode";
-import { defaultJurySize, Episode, GameState } from "../../model";
+import { defaultJurySize, Episode, GameState, PlayerProfile } from "../../model";
 import { Scene } from "../episode/scenes/scene";
-import { defaultCast, newEpisode } from "../../subjects/subjects";
+import { cast$, mainContentStream$, newEpisode } from "../../subjects/subjects";
 import { Box } from "../layout/box";
 import { HasText } from "../layout/text";
+import { shuffle } from "lodash";
 interface SidebarState {
     episodes: Episode[];
     selectedScene: number;
 }
+const baseUrl = "https://spaulmark.github.io/img/";
+
+let firstLoad = true;
 
 export class Sidebar extends React.Component<{}, SidebarState> {
     private controller: SidebarController;
@@ -17,15 +21,35 @@ export class Sidebar extends React.Component<{}, SidebarState> {
         super(props);
         this.controller = new SidebarController(this);
         this.state = { episodes: [], selectedScene: 0 };
-        newEpisode(
-            new PregameEpisode(
-                new GameState({ players: defaultCast, jury: defaultJurySize(defaultCast.length) })
-            )
-        );
     }
-
-    public componentDidMount() {
+    public async componentDidMount() {
         document.addEventListener("keydown", this.controller.handleKeyDown);
+        if (!firstLoad) {
+            firstLoad = false;
+            return;
+        }
+        const data = await (await fetch(`${baseUrl}dir.json`)).json();
+        const bb = data.decks.filter((file: string) => file.match("Big Brother"));
+        let allBBs: PlayerProfile[] = [];
+        for (const cast of bb) {
+            const bbPlayers = await (await fetch(`${baseUrl}${cast}/dir.json`)).json();
+            bbPlayers.files.forEach((player: string) => {
+                const name = player.substr(0, player.lastIndexOf(".")) || player;
+                if (name === "Julie") return;
+                allBBs.push({
+                    name,
+                    imageURL: `${baseUrl}${cast}/${player}`,
+                });
+            });
+        }
+        allBBs = shuffle(allBBs);
+        allBBs = allBBs.slice(0, 16);
+        const episode: Episode = new PregameEpisode(
+            new GameState({ players: allBBs, jury: defaultJurySize(allBBs.length) })
+        );
+        newEpisode(episode);
+        cast$.next(allBBs);
+        mainContentStream$.next(episode.render);
     }
 
     public componentWillUnmount() {

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { SidebarController } from "./sidebarController";
 import { PregameEpisode } from "../episode/pregameEpisode";
 import { defaultJurySize, Episode, GameState } from "../../model";
-import { Scene } from "../episode/scene";
+import { Scene } from "../episode/scenes/scene";
 import { defaultCast, newEpisode } from "../../subjects/subjects";
 import { Box } from "../layout/box";
 import { HasText } from "../layout/text";

--- a/src/components/sidebar/sidebarController.ts
+++ b/src/components/sidebar/sidebarController.ts
@@ -2,7 +2,7 @@ import { Subscription } from "rxjs";
 import { Sidebar } from "./sidebar";
 import { EpisodeLibrary, Season } from "../../model/season";
 import { Episode, nonEvictedHouseguests, getById } from "../../model";
-import { Scene } from "../episode/scene";
+import { Scene } from "../episode/scenes/scene";
 import {
     mainContentStream$,
     episodes$,

--- a/src/components/topbar/themeSwitch.tsx
+++ b/src/components/topbar/themeSwitch.tsx
@@ -1,26 +1,26 @@
 import React, { useState } from "react";
 import { theme$ } from "../../subjects/subjects";
-import { darkTheme, lightTheme } from "../../theme/theme";
+import { darkTheme } from "../../theme/theme";
 
 // this class is temporarily unused, but in the future it will be used for custom themes
-export function ThemeSwitcher() {
-    const [theme, setTheme] = useState(
-        window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
-    );
-    const toggleTheme = () => {
-        if (theme === "light") {
-            setTheme("dark");
-            theme$.next(darkTheme);
-        } else {
-            setTheme("light");
-            theme$.next(lightTheme);
-        }
-    };
+// export function ThemeSwitcher() {
+//     const [theme, setTheme] = useState(
+//         window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+//     );
+//     const toggleTheme = () => {
+//         if (theme === "light") {
+//             setTheme("dark");
+//             theme$.next(darkTheme);
+//         } else {
+//             setTheme("light");
+//             theme$.next(lightTheme);
+//         }
+//     };
 
-    const className = `button ${theme === "dark" ? `is-dark` : "is-light"}`;
-    return (
-        <div className={className} onClick={toggleTheme}>
-            {theme === "light" ? "Dark mode" : "Light mode"}
-        </div>
-    );
-}
+//     const className = `button ${theme === "dark" ? `is-dark` : "is-light"}`;
+//     return (
+//         <div className={className} onClick={toggleTheme}>
+//             {theme === "light" ? "Dark mode" : "Light mode"}
+//         </div>
+//     );
+// }

--- a/src/model/logging/episodelog.ts
+++ b/src/model/logging/episodelog.ts
@@ -6,9 +6,10 @@ export class EpisodeLog {
     public winner?: number;
     public runnerUp?: number;
     public nominationsPostVeto: string[] = [];
-    public evicted: number = -1; // TODO: but what if multiple people were evicted in one row
+    public evicted: number[] = [];
     public votes: { [id: string]: VoteType } = {};
     public votesInMajority: number = -1;
     public outOf: number = -1;
     public soleVoter?: string;
+    public votingTo?: string;
 }

--- a/src/model/logging/episodelog.ts
+++ b/src/model/logging/episodelog.ts
@@ -6,7 +6,7 @@ export class EpisodeLog {
     public winner?: number;
     public runnerUp?: number;
     public nominationsPostVeto: string[] = [];
-    public evicted: number = -1;
+    public evicted: number = -1; // TODO: but what if multiple people were evicted in one row
     public votes: { [id: string]: VoteType } = {};
     public votesInMajority: number = -1;
     public outOf: number = -1;

--- a/src/model/logging/voteType.tsx
+++ b/src/model/logging/voteType.tsx
@@ -7,6 +7,7 @@ import {
     RunnerUpCell,
     NomineeCell,
     HohCell,
+    SaveCell,
 } from "../../components/episode/scenes/votingTable";
 
 let voteKey = 0;
@@ -18,6 +19,18 @@ function getKey(): string {
 export interface VoteType {
     id: number;
     render: (state: GameState) => JSX.Element;
+}
+
+export class SaveVote implements VoteType {
+    id: number;
+    render = (state: GameState) => (
+        <SaveCell key={getKey()}>
+            <Centered noMargin={true}>{getById(state, this.id).name}</Centered>
+        </SaveCell>
+    );
+    constructor(id: number) {
+        this.id = id;
+    }
 }
 
 export class NormalVote implements VoteType {

--- a/src/subjects/subjects.tsx
+++ b/src/subjects/subjects.tsx
@@ -5,35 +5,10 @@ import { SelectedPlayerData } from "../components/playerPortrait/selectedPortrai
 import React from "react";
 import { PortraitDisplayMode, popularityMode } from "../model/portraitDisplayMode";
 import { ColorTheme } from "../theme/theme";
-import { shuffle } from "lodash";
 import { EpisodeLibrary } from "../model/season";
 
-const baseURL = "https://spaulmark.github.io/img//Big%20Brother%20Canada%2010/";
-const defaultNames = shuffle([
-    "Betty",
-    "Hermon",
-    "Josh",
-    "Melina",
-    "Tynesha",
-    "Jacey Lynne",
-    "Kevin",
-    "Moose",
-    "Gino",
-    "Jay",
-    "Kyle",
-    "Stephanie",
-    "Haleena",
-    "Jess",
-    "Marty",
-    "Summer",
-]);
-export const defaultCast: PlayerProfile[] = defaultNames.map((name) => ({
-    name,
-    imageURL: `${baseURL}${name}.jpg`,
-}));
-
 // What is currently being displayed.
-export const mainContentStream$ = new BehaviorSubject(<PregameScreen cast={defaultCast} />);
+export const mainContentStream$ = new BehaviorSubject(<PregameScreen cast={[]} />);
 // Push episodes to this subject to add them to the sidebar. Null resets everything.
 export const episodes$ = new BehaviorSubject<Episode | null>(null);
 // Forcibly switches to an episode. Used when adding a new episode.
@@ -49,7 +24,7 @@ export function switchSceneRelative(n: number) {
 export const season$ = new Subject<EpisodeLibrary>();
 
 // the list of players in the game
-export const cast$ = new BehaviorSubject<PlayerProfile[]>(defaultCast);
+export const cast$ = new BehaviorSubject<PlayerProfile[]>([]);
 export function updateCast(newCast: PlayerProfile[]) {
     cast$.next(newCast);
 }

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -3,7 +3,6 @@ export interface ColorTheme {
     bg: string;
     text: string;
     toggleBorder: string;
-    gradient: string;
     bodyArea: string;
     link: string;
     mark: string;
@@ -13,40 +12,40 @@ export interface ColorTheme {
     winnerCell: string;
     lightGrayCell: string;
     runnerUpCell: string;
+    saveCell: string;
     nomineeCell: string;
     hohCell: string;
     portraitBorder: string;
     tableCellBorder: string;
 }
 
-export const lightTheme: ColorTheme = {
-    name: "light",
-    bg: "#fff",
-    text: "#363537",
-    toggleBorder: "#FFF",
-    gradient: "linear-gradient(#39598A, #79D7ED)",
-    bodyArea: "#fff",
-    link: "blue",
-    mark: "yellow",
-    overlay: "fff",
-    evictedCell: "#fa8072",
-    grayCell: "#eaecf0",
-    lightGrayCell: "#f8f9fa",
-    winnerCell: "#73fb76",
-    runnerUpCell: "#d1e8ef",
-    nomineeCell: "#959ffd",
-    hohCell: "#CCFFCC",
-    portraitBorder: "gray",
-    tableCellBorder: "#a2a9b1",
-};
+// export const lightTheme: ColorTheme = {
+//     name: "light",
+//     bg: "#fff",
+//     text: "#363537",
+//     toggleBorder: "#FFF",
+//     bodyArea: "#fff",
+//     link: "blue",
+//     mark: "yellow",
+//     overlay: "fff",
+//     evictedCell: "#fa8072",
+//     grayCell: "#eaecf0",
+//     lightGrayCell: "#f8f9fa",
+//     winnerCell: "#73fb76",
+//     runnerUpCell: "#d1e8ef",
+//     nomineeCell: "#959ffd",
+//     hohCell: "#CCFFCC",
+//     portraitBorder: "gray",
+//     tableCellBorder: "#a2a9b1",
+// };
 
 export const darkTheme: ColorTheme = {
     name: "dark",
     bg: "#121212",
+    saveCell: "#334d5e",
     text: "#FAFAFA",
     bodyArea: "#363537",
     toggleBorder: "#6B8096",
-    gradient: "linear-gradient(#091236, #1E215D)",
     link: "lightblue",
     mark: "#7e006d",
     overlay: "#444346",

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -229,7 +229,7 @@ function useGoldenVetoPreJury(
     nominees: Houseguest[],
     gameState: GameState
 ): HouseguestWithLogic {
-    let reason = "Neither of these nominees are my friends.";
+    let reason = "None of these nominees are my friends.";
     let potentialSave: Houseguest | null = null;
     let alwaysSave: Houseguest | null = null;
     nominees.forEach((nominee) => {

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -8,7 +8,7 @@ import {
 } from "./classifyRelationship";
 import { getRelationshipSummary, isBetterTarget } from "./targets";
 
-interface NumberWithLogic {
+export interface NumberWithLogic {
     decision: number;
     reason: string;
 }
@@ -19,6 +19,31 @@ interface HouseguestWithLogic {
 }
 
 // Return the index of the eviction target.
+
+// vote to save, in the future, generalize this to n nominees instead of going 2 by 2
+export function castVoteToSave(
+    hero: Houseguest,
+    nominees: Houseguest[],
+    gameState: GameState
+): NumberWithLogic {
+    if (nominees.length === 0) throw new Error("Tried to cast a vote to save with no nominees.");
+    let currentSave: NumberWithLogic = { decision: 0, reason: "" };
+    nominees.forEach((nominee, i) => {
+        if (i === 0) return;
+        const evictionTarget = castEvictionVote(hero, [nominee, nominees[currentSave.decision]], gameState);
+        if (!currentSave.reason) {
+            currentSave.reason = evictionTarget.reason;
+        }
+        if (evictionTarget.decision === 1) {
+            currentSave = { decision: i, reason: evictionTarget.reason };
+        }
+    });
+    return currentSave;
+}
+
+// TODO: generalize this to 3 nominees now hahahahahahaHAHAHAHAHAHAHAH
+
+// returns the index in the array of the person you're voting to evict
 export function castEvictionVote(
     hero: Houseguest,
     nominees: Houseguest[],
@@ -151,7 +176,7 @@ function cutthroatVote(hero: Houseguest, nominees: Houseguest[]): NumberWithLogi
         const decision = hero.relationships[nom0.id] < hero.relationships[nom1.id] ? 0 : 1;
         return {
             decision,
-            reason: `Both noms are my enemies, but I dislike ${nominees[decision].name} more.`,
+            reason: `I dislike ${nominees[decision].name} the most of these enemies.`,
         };
     } else if (
         (r0 === Relationship.Enemy && r1 !== Relationship.Enemy) ||
@@ -170,7 +195,7 @@ function cutthroatVote(hero: Houseguest, nominees: Houseguest[]): NumberWithLogi
     const vote = lowestScore(hero, nominees, relationship);
     return {
         decision: vote,
-        reason: `Both noms are my friends, but I like ${nominees[vote === 0 ? 1 : 0].name} more.`,
+        reason: `I like ${nominees[vote === 0 ? 1 : 0].name} the most of these friends.`,
     };
 }
 

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -208,22 +208,20 @@ export function useGoldenVeto(
     gameState: GameState,
     HoH: number
 ): HouseguestWithLogic {
-    let result: HouseguestWithLogic;
     if (hero.id === HoH) {
         return { decision: null, reason: "I support my original nominations." };
     }
-    if (hero.id == nominees[0].id || hero.id == nominees[1].id) {
-        result = { decision: hero, reason: "I am going to save myself." };
-    } else {
-        result = useGoldenVetoPreJury(hero, nominees, gameState);
-        if (gameState.remainingPlayers === 4) {
-            result = {
-                decision: null,
-                reason: "It doesn't make sense to use the veto here.",
-            };
-        }
+    for (const nom of nominees) {
+        if (hero.id === nom.id) return { decision: hero, reason: "I am going to save myself." };
     }
-    return result || null;
+    // if you're not nominated, don't use the veto if you are the only replacement nominee
+    if (gameState.remainingPlayers - 1 - nominees.length === 1) {
+        return {
+            decision: null,
+            reason: "It doesn't make sense to use the veto here.",
+        };
+    }
+    return useGoldenVetoPreJury(hero, nominees, gameState) || null;
 }
 
 function useGoldenVetoPreJury(

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -41,8 +41,6 @@ export function castVoteToSave(
     return currentSave;
 }
 
-// TODO: generalize this to 3 nominees now hahahahahahaHAHAHAHAHAHAHAH
-
 // returns the index in the array of the person you're voting to evict
 export function castEvictionVote(
     hero: Houseguest,

--- a/src/utils/listStrings.ts
+++ b/src/utils/listStrings.ts
@@ -10,3 +10,13 @@ export function listNames(names: string[]): string {
     }
     return names.slice(0, names.length - 1).join(", ") + ", and " + names[names.length - 1];
 }
+
+export function listVotes(votes: string[]): string {
+    if (votes.length === 0) {
+        return "";
+    }
+    if (votes.length === 1) {
+        return votes[0];
+    }
+    return votes.slice(0, votes.length - 1).join(` to `) + ` to ` + votes[votes.length - 1];
+}

--- a/src/utils/listStrings.ts
+++ b/src/utils/listStrings.ts
@@ -18,5 +18,8 @@ export function listVotes(votes: string[]): string {
     if (votes.length === 1) {
         return votes[0];
     }
-    return votes.slice(0, votes.length - 1).join(` to `) + ` to ` + votes[votes.length - 1];
+    if (votes.length === 2) {
+        return votes[0] + " to " + votes[1];
+    }
+    return votes.slice(0, votes.length - 1).join(` - `) + ` - ` + votes[votes.length - 1];
 }

--- a/src/utils/names.ts
+++ b/src/utils/names.ts
@@ -1,0 +1,12 @@
+export function listNames(names: string[]): string {
+    if (names.length === 0) {
+        return "";
+    }
+    if (names.length === 1) {
+        return names[0];
+    }
+    if (names.length === 2) {
+        return names[0] + " and " + names[1];
+    }
+    return names.slice(0, names.length - 1).join(", ") + ", and " + names[names.length - 1];
+}


### PR DESCRIPTION
Patch Notes [Triple Eviction Night Update]:

Features:
- Initial cast is now randomized among Big Brother players
- Triple Evictions (Canada style) can now be added to games
- Triple Evictions (US style) can now be added to games

Cosmetic Updates:
- Upgraded the look of the season editor page

Cast news:
- New casts: Big Brother seasons 8-23
- New casts: The Genius seasons 1-4
- New cast: European Soccer Mascots ( contributed by @domasan12#2527 )
- New cast: Hetalia Axis Powers ( contributed by @domasan12#2527 )
- Optimized images for Battle for Dream Island
- Updated cast: Brazillian Soccer Mascots ( updated by @domasan12#2527 )

Bugfixes:
- Fixed a bug where adding and removing twists can cause FX/Week X text to display incorrectly on the twist editor screen
