### PR TITLE
Instant eviction update

### DIFF
--- a/src/components/castingScreen/castingScreen.tsx
+++ b/src/components/castingScreen/castingScreen.tsx
@@ -5,13 +5,14 @@ import { SetupPortrait } from "../playerPortrait/setupPortrait";
 import { shuffle } from "lodash";
 import { RandomButton } from "./randomXButton";
 import { selectCastPlayer } from "../playerPortrait/selectedPortrait";
-import { mainContentStream$, selectedCastPlayer$, updateCast } from "../../subjects/subjects";
+import { pushToMainContentStream, selectedCastPlayer$, updateCast } from "../../subjects/subjects";
 import { HasText, Input } from "../layout/text";
 import { Centered } from "../layout/centered";
 import { Subscription } from "rxjs";
 import _ from "lodash";
 import { HelpLink } from "../episode/allianceList";
 import { SeasonEditorPage } from "../seasonEditor/seasonEditorPage";
+import { Screens } from "../topbar/topBar";
 
 interface CastingScreenProps {
     cast?: PlayerProfile[];
@@ -92,15 +93,9 @@ export class CastingScreen extends React.Component<CastingScreenProps, CastingSc
         return <div className="columns is-gapless is-mobile is-multiline is-centered">{rows}</div>;
     }
 
-    private appendProfiles = (profiles: PlayerProfile[]) => {
-        const newState = { ...this.state };
-        profiles.forEach((profile) => newState.players.push(profile));
-        this.setState(newState);
-    };
-
     private submit = () => {
         updateCast(this.state.players);
-        mainContentStream$.next(<SeasonEditorPage />);
+        pushToMainContentStream(<SeasonEditorPage />, Screens.Season);
     };
 
     private random = (_amount: number) => {

--- a/src/components/castingScreen/randomXButton.tsx
+++ b/src/components/castingScreen/randomXButton.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Tooltip } from "../tooltip/tooltip";
 import { NumericInput } from "./numericInput";
 
 interface RandomButtonProps {
@@ -10,13 +11,15 @@ export function RandomButton(props: RandomButtonProps): JSX.Element {
     return (
         <div className="field has-addons" style={{ display: "flex" }}>
             <div className="control">
-                <button
-                    disabled={number === ""}
-                    className="button is-primary"
-                    onClick={() => props.random(parseInt(number))}
-                >
-                    Random
-                </button>
+                <Tooltip text={"Selected cast members will always be chosen."}>
+                    <button
+                        disabled={number === ""}
+                        className="button is-primary"
+                        onClick={() => props.random(parseInt(number))}
+                    >
+                        Random
+                    </button>
+                </Tooltip>
             </div>
             <div className="control">
                 <NumericInput value={number} onChange={setNumber} />

--- a/src/components/deckScreen/deckScreen.tsx
+++ b/src/components/deckScreen/deckScreen.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import ReactPaginate from "react-paginate";
 import { HasText } from "../layout/text";
 import { shuffle, ceil, debounce } from "lodash";
-import { mainContentStream$, selectDeckSubject, selectedDecks$ } from "../../subjects/subjects";
+import { pushToMainContentStream, selectDeckSubject, selectedDecks$ } from "../../subjects/subjects";
 import { CastingScreen } from "../castingScreen/castingScreen";
 import _ from "lodash";
 import styled from "styled-components";
 import { Subscription } from "rxjs";
 import { selectedColor } from "../playerPortrait/houseguestPortraitController";
 import { PlayerProfile } from "../../model";
+import { Screens } from "../topbar/topBar";
 
 interface DeckScreenProps {}
 
@@ -71,7 +72,7 @@ async function submitCasts(casts: Set<string>) {
         playerProfiles.push(...folderProfiles);
     }
 
-    mainContentStream$.next(<CastingScreen cast={playerProfiles} />);
+    pushToMainContentStream(<CastingScreen cast={playerProfiles} />, Screens.Casting);
 }
 
 function Deck(props: { deck: string; selected: boolean }): JSX.Element {

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -132,6 +132,9 @@ export function generateBBVanillaScenes(
         doubleEviction,
         votingTo: "Evict",
     });
+    if (veto === null) {
+        currentGameState.currentLog.nominationsPostVeto = currentGameState.currentLog.nominationsPreVeto;
+    }
     scenes.push(evictionScene);
     const title = `Week ${currentGameState.phase}`;
     return { gameState: currentGameState, scenes, title };

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -11,6 +11,7 @@ import { HasText } from "../layout/text";
 import styled from "styled-components";
 import { weekStartTab$ } from "../../subjects/subjects";
 import { WeekStartWrapper } from "./bigBrotherWeekstartWrapper";
+import { GoldenVeto, Veto } from "./veto/veto";
 
 export const BigBrotherVanilla: EpisodeType = {
     canPlayWith: (n: number) => {
@@ -70,7 +71,7 @@ export function defaultContent(initialGameState: GameState) {
 }
 
 export function generateBbVanilla(initialGamestate: GameState): Episode {
-    const episode = generateBBVanillaScenes(initialGamestate);
+    const episode = generateBBVanillaScenes(initialGamestate, GoldenVeto);
     return new Episode({
         title: episode.title,
         scenes: episode.scenes,
@@ -82,6 +83,7 @@ export function generateBbVanilla(initialGamestate: GameState): Episode {
 
 export function generateBBVanillaScenes(
     initialGamestate: GameState,
+    veto: Veto | null,
     doubleEviction: boolean = false
 ): {
     gameState: GameState;
@@ -103,26 +105,28 @@ export function generateBBVanillaScenes(
     });
     scenes.push(nomCeremonyScene);
 
-    let vetoCompScene;
-    let povWinner: Houseguest;
-    [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
-        currentGameState,
-        hoh,
-        nominees,
-        doubleEviction
-    );
-    scenes.push(vetoCompScene);
-    let vetoCeremonyScene;
+    if (veto) {
+        let vetoCompScene;
+        let povWinner: Houseguest;
+        [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
+            currentGameState,
+            hoh,
+            nominees,
+            veto,
+            doubleEviction
+        );
+        scenes.push(vetoCompScene);
+        let vetoCeremonyScene;
 
-    [currentGameState, vetoCeremonyScene, nominees] = generateVetoCeremonyScene(
-        currentGameState,
-        hoh,
-        nominees,
-        povWinner,
-        { doubleEviction, finalNominees: 2 }
-    );
-    scenes.push(vetoCeremonyScene);
-
+        [currentGameState, vetoCeremonyScene, nominees] = generateVetoCeremonyScene(
+            currentGameState,
+            hoh,
+            nominees,
+            povWinner,
+            { doubleEviction, finalNominees: 2 }
+        );
+        scenes.push(vetoCeremonyScene);
+    }
     let evictionScene;
     [currentGameState, evictionScene] = generateEvictionScene(currentGameState, hoh, nominees, {
         doubleEviction,

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -23,6 +23,8 @@ function generateInstantEviction(initialGamestate: GameState): Episode {
     currentGameState.incrementLogIndex();
     const doubleEviction = generateBBVanillaScenes(currentGameState, null, true);
     currentGameState = doubleEviction.gameState;
+    doubleEviction.gameState.currentLog.nominationsPostVeto =
+        doubleEviction.gameState.currentLog.nominationsPreVeto;
     scenes.push(
         new Scene({
             title: "Instant Eviction",

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -23,8 +23,7 @@ function generateInstantEviction(initialGamestate: GameState): Episode {
     currentGameState.incrementLogIndex();
     const doubleEviction = generateBBVanillaScenes(currentGameState, null, true);
     currentGameState = doubleEviction.gameState;
-    doubleEviction.gameState.currentLog.nominationsPostVeto =
-        doubleEviction.gameState.currentLog.nominationsPreVeto;
+
     scenes.push(
         new Scene({
             title: "Instant Eviction",

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -1,30 +1,31 @@
+import React from "react";
 import { GameState } from "../../model";
 import { generateBBVanillaScenes } from "./bigBrotherEpisode";
-import { Episode, EpisodeType } from "./episodes";
-import React from "react";
+import { DoubleEviction } from "./doubleEvictionEpisode";
+import { EpisodeType, Episode } from "./episodes";
 import { Scene } from "./scenes/scene";
 import { GoldenVeto } from "./veto/veto";
 
-export const DoubleEviction: EpisodeType = {
+export const InstantEviction: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
     eliminates: 2,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "Double Eviction",
-    generate: generateDoubleEviction,
+    name: "Instant Eviction",
+    generate: generateInstantEviction,
 };
 
-function generateDoubleEviction(initialGamestate: GameState): Episode {
+function generateInstantEviction(initialGamestate: GameState): Episode {
     const episode = generateBBVanillaScenes(initialGamestate, GoldenVeto);
     let currentGameState = episode.gameState;
     const scenes: Scene[] = episode.scenes;
 
     currentGameState.incrementLogIndex();
-    const doubleEviction = generateBBVanillaScenes(currentGameState, GoldenVeto, true);
+    const doubleEviction = generateBBVanillaScenes(currentGameState, null, true);
     currentGameState = doubleEviction.gameState;
     scenes.push(
         new Scene({
-            title: "Double Eviction",
+            title: "Instant Eviction",
             content: <div>{doubleEviction.scenes.map((scene) => scene.content)}</div>,
             gameState: doubleEviction.gameState,
         })

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -116,6 +116,16 @@ export function generateEvictionScene(
     nominees.forEach((hg) => {
         newGameState.currentLog.votes[hg.id] = new NomineeVote(evicteesSet.has(hg.id));
     });
+
+    const votesPerEvictee: any = {};
+    nominees.forEach((hg, i) => {
+        if (!evicteesSet.has(hg.id)) return;
+        votesPerEvictee[hg.id] = voteCounts[i] + (tieBreaker.decision === i ? 1 : 0);
+    });
+
+    if (options.votingTo === "Evict") evictees.sort((a, b) => votesPerEvictee[b.id] - votesPerEvictee[a.id]);
+    else evictees.sort((a, b) => votesPerEvictee[a.id] - votesPerEvictee[b.id]);
+
     evictees.forEach((evictee) => {
         newGameState = evictHouseguest(newGameState, evictee.id);
     });

--- a/src/components/episode/scenes/vetoCompScene.tsx
+++ b/src/components/episode/scenes/vetoCompScene.tsx
@@ -12,11 +12,13 @@ import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
 import { listNames } from "../../../utils/listStrings";
+import { Veto } from "../veto/veto";
 
 export function generateVetoCompScene(
     initialGameState: GameState,
     HoH: Houseguest,
     nominees: Houseguest[],
+    veto: Veto,
     doubleEviction: boolean = false
 ): [GameState, Scene, Houseguest] {
     const newGameState = new MutableGameState(initialGameState);
@@ -71,7 +73,7 @@ export function generateVetoCompScene(
                 <Portraits centered={true} houseguests={extras} />
                 <Centered>...</Centered>
                 <Portraits centered={true} houseguests={[povWinner]} />
-                <CenteredBold>{`${povWinner.name} has won the Golden Power of Veto!`}</CenteredBold>
+                <CenteredBold>{`${povWinner.name} has won the ${veto.name}!`}</CenteredBold>
                 {!doubleEviction && <NextEpisodeButton />}
             </div>
         ),

--- a/src/components/episode/scenes/votingTable.tsx
+++ b/src/components/episode/scenes/votingTable.tsx
@@ -296,7 +296,7 @@ function generatePreVetoRow(log: EpisodeLog | undefined, i: number, cells: JSX.E
         );
         return;
     }
-    if (log.nominationsPreVeto.length === 0) {
+    if (log.nominationsPreVeto.length === 0 || log.vetoWinner === undefined) {
         cells.push(
             <White key={`preveto--${i}-${anotherKey++}`} rowSpan={2}>
                 <CenteredItallic noMargin={true}>(none)</CenteredItallic>

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -7,6 +7,7 @@ import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
 import { generateVetoCompScene } from "./scenes/vetoCompScene";
 import { generateVetoCeremonyScene } from "./scenes/vetoCeremonyScene";
 import { generateEvictionScene } from "./scenes/evictionScene";
+import { GoldenVeto } from "./veto/veto";
 
 export const TripleEvictionCad: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
@@ -18,7 +19,7 @@ export const TripleEvictionCad: EpisodeType = {
 };
 
 export function generateTripleEvictionCad(initialGamestate: GameState): Episode {
-    const episode = generateBBVanillaScenes(initialGamestate);
+    const episode = generateBBVanillaScenes(initialGamestate, GoldenVeto);
     let currentGameState = episode.gameState;
     const scenes: Scene[] = episode.scenes;
 
@@ -47,6 +48,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
         currentGameState,
         hoh,
         nominees,
+        GoldenVeto,
         true
     );
     tripleScenes.push(vetoCompScene);

--- a/src/components/episode/tripleEvictionEpisodeUs.tsx
+++ b/src/components/episode/tripleEvictionEpisodeUs.tsx
@@ -2,6 +2,7 @@ import { Episode, EpisodeType, GameState } from "../../model";
 import React from "react";
 import { generateBBVanillaScenes } from "./bigBrotherEpisode";
 import { Scene } from "./scenes/scene";
+import { GoldenVeto } from "./veto/veto";
 
 export const TripleEvictionUs: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
@@ -13,12 +14,12 @@ export const TripleEvictionUs: EpisodeType = {
 };
 
 export function generateTripleEvictionUs(initialGamestate: GameState): Episode {
-    const episode = generateBBVanillaScenes(initialGamestate);
+    const episode = generateBBVanillaScenes(initialGamestate, GoldenVeto);
     let currentGameState = episode.gameState;
     const scenes: Scene[] = episode.scenes;
 
     currentGameState.incrementLogIndex();
-    const doubleEviction = generateBBVanillaScenes(currentGameState, true);
+    const doubleEviction = generateBBVanillaScenes(currentGameState, GoldenVeto, true);
     currentGameState = doubleEviction.gameState;
     scenes.push(
         new Scene({
@@ -28,7 +29,7 @@ export function generateTripleEvictionUs(initialGamestate: GameState): Episode {
         })
     );
     currentGameState.incrementLogIndex();
-    const tripleEviction = generateBBVanillaScenes(currentGameState, true);
+    const tripleEviction = generateBBVanillaScenes(currentGameState, GoldenVeto, true);
     currentGameState = tripleEviction.gameState;
     scenes.push(
         new Scene({

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -1,0 +1,8 @@
+export interface Veto {
+    name: string;
+    // TODO: something like GenerateScenes() that returns veto comp scene
+}
+
+export const GoldenVeto: Veto = {
+    name: "Golden Power of Veto",
+};

--- a/src/components/playerPortrait/houseguestPortrait.tsx
+++ b/src/components/playerPortrait/houseguestPortrait.tsx
@@ -75,6 +75,7 @@ export interface PortraitProps {
     friends?: number;
     enemies?: number;
     targetingMe?: number;
+    targets?: number[];
 }
 
 export interface PortraitState {
@@ -103,7 +104,11 @@ export class HouseguestPortrait extends React.Component<PortraitProps, PortraitS
     }
 
     private onClick(): void {
-        if (isNotWellDefined(this.props.id) || !this.props.relationships) {
+        if (
+            (this.props.targets && this.props.targets[0] === 0 && this.props.targets[1] == 0) ||
+            isNotWellDefined(this.props.id) ||
+            !this.props.relationships
+        ) {
             return;
         }
         const data = {

--- a/src/components/pregameScreen/pregameScreen.tsx
+++ b/src/components/pregameScreen/pregameScreen.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { PlayerProfile } from "../../model";
 import { MemoryWall } from "../memoryWall";
-import { NextEpisodeButton } from "../nextEpisodeButton/nextEpisodeButton";
-import { ChooseCastLink } from "../topbar/topBar";
 import { HasText } from "../layout/text";
 import { popularityMode } from "../../model/portraitDisplayMode";
-import { displayMode$ } from "../../subjects/subjects";
+import { displayMode$, getCast, mainContentStream$, switchSceneRelative } from "../../subjects/subjects";
 import { selectedColor } from "../playerPortrait/houseguestPortraitController";
+import { TopbarLink } from "../topbar/topBar";
+import { SeasonEditorPage } from "../seasonEditor/seasonEditorPage";
+import { Centered, CenteredBold } from "../layout/centered";
+import { CastingScreen } from "../castingScreen/castingScreen";
+import { DeckScreen } from "../deckScreen/deckScreen";
 
 interface PregameScreenProps {
     cast: PlayerProfile[];
@@ -30,11 +33,48 @@ export class PregameScreen extends React.Component<PregameScreenProps, {}> {
                 >
                     Big Brother Bots
                 </h2>
-                {props.cast.length === 0 ? "Loading..." : <MemoryWall houseguests={props.cast} />}
-                <p>
-                    <b> {"You can use the <- and -> arrow keys to move forwards and backwards."}</b>
-                </p>
-                <NextEpisodeButton />
+                <CenteredBold>Big Brother Bots is a simulator for the reality show Big Brother.</CenteredBold>
+                <Centered>
+                    <TopbarLink
+                        onClick={() => {
+                            mainContentStream$.next(<DeckScreen />);
+                        }}
+                    >
+                        Choose characters
+                    </TopbarLink>{" "}
+                    from 300+ collections, or{" "}
+                    <TopbarLink
+                        onClick={() => {
+                            mainContentStream$.next(<CastingScreen cast={[]} />);
+                        }}
+                    >
+                        upload your own
+                    </TopbarLink>
+                    , then{" "}
+                    <TopbarLink
+                        onClick={() => {
+                            mainContentStream$.next(<SeasonEditorPage />);
+                        }}
+                    >
+                        add twists
+                    </TopbarLink>{" "}
+                    and watch as everyone votes each other out until one winner remains!{" "}
+                </Centered>
+                {props.cast.length === 0 ? "" : <MemoryWall houseguests={props.cast} />}
+                {props.cast.length === 0 ? (
+                    ""
+                ) : (
+                    <p>
+                        <b> {"You can use the ⬅️ and ➡️ arrow keys to move forwards and backwards."}</b>
+                    </p>
+                )}
+                {props.cast.length === 0 ? (
+                    ""
+                ) : (
+                    <button className="button is-success" onClick={() => switchSceneRelative(1)}>
+                        Start Game
+                    </button>
+                )}
             </HasText>
         );
     }

--- a/src/components/pregameScreen/pregameScreen.tsx
+++ b/src/components/pregameScreen/pregameScreen.tsx
@@ -3,9 +3,14 @@ import { PlayerProfile } from "../../model";
 import { MemoryWall } from "../memoryWall";
 import { HasText } from "../layout/text";
 import { popularityMode } from "../../model/portraitDisplayMode";
-import { displayMode$, getCast, mainContentStream$, switchSceneRelative } from "../../subjects/subjects";
+import {
+    displayMode$,
+    mainContentStream$,
+    pushToMainContentStream,
+    switchSceneRelative,
+} from "../../subjects/subjects";
 import { selectedColor } from "../playerPortrait/houseguestPortraitController";
-import { TopbarLink } from "../topbar/topBar";
+import { Screens, TopbarLink } from "../topbar/topBar";
 import { SeasonEditorPage } from "../seasonEditor/seasonEditorPage";
 import { Centered, CenteredBold } from "../layout/centered";
 import { CastingScreen } from "../castingScreen/castingScreen";
@@ -37,7 +42,7 @@ export class PregameScreen extends React.Component<PregameScreenProps, {}> {
                 <Centered>
                     <TopbarLink
                         onClick={() => {
-                            mainContentStream$.next(<DeckScreen />);
+                            pushToMainContentStream(<DeckScreen />, Screens.Deck);
                         }}
                     >
                         Choose characters
@@ -45,7 +50,7 @@ export class PregameScreen extends React.Component<PregameScreenProps, {}> {
                     from 300+ collections, or{" "}
                     <TopbarLink
                         onClick={() => {
-                            mainContentStream$.next(<CastingScreen cast={[]} />);
+                            pushToMainContentStream(<CastingScreen cast={[]} />, Screens.Casting);
                         }}
                     >
                         upload your own
@@ -53,7 +58,7 @@ export class PregameScreen extends React.Component<PregameScreenProps, {}> {
                     , then{" "}
                     <TopbarLink
                         onClick={() => {
-                            mainContentStream$.next(<SeasonEditorPage />);
+                            pushToMainContentStream(<SeasonEditorPage />, Screens.Season);
                         }}
                     >
                         add twists

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import { defaultJurySize, GameState, validateJurySize } from "../../model/gameState";
-import { cast$, mainContentStream$, newEpisode, season$ } from "../../subjects/subjects";
+import { cast$, newEpisode, pushToMainContentStream, season$ } from "../../subjects/subjects";
 import { NumericInput } from "../castingScreen/numericInput";
 import { DoubleEviction } from "../episode/doubleEvictionEpisode";
 import { EpisodeType } from "../episode/episodes";
@@ -13,6 +13,7 @@ import { HasText } from "../layout/text";
 import { selectPlayer } from "../playerPortrait/selectedPortrait";
 import { Noselect } from "../playerPortrait/setupPortrait";
 import { PregameScreen } from "../pregameScreen/pregameScreen";
+import { Screens } from "../topbar/topBar";
 import { getEpisodeLibrary, SeasonEditorList } from "./seasonEditorList";
 import { TwistAdder } from "./twistAdder";
 
@@ -31,7 +32,7 @@ const submit = async (jury: number): Promise<void> => {
     season$.next(getEpisodeLibrary());
 
     // reset stuff and start a new game
-    mainContentStream$.next(<PregameScreen cast={cast$.value} />);
+    pushToMainContentStream(<PregameScreen cast={cast$.value} />, Screens.Other);
     selectPlayer(null);
     // vscode says the awaits are unnessecary here,
     // but if you remove them then bad things happen

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -5,6 +5,7 @@ import { cast$, mainContentStream$, newEpisode, season$ } from "../../subjects/s
 import { NumericInput } from "../castingScreen/numericInput";
 import { DoubleEviction } from "../episode/doubleEvictionEpisode";
 import { EpisodeType } from "../episode/episodes";
+import { InstantEviction } from "../episode/instantEvictionEpisode";
 import { PregameEpisode } from "../episode/pregameEpisode";
 import { TripleEvictionCad } from "../episode/tripleEvictionEpisodeCad";
 import { TripleEvictionUs } from "../episode/tripleEvictionEpisodeUs";
@@ -24,7 +25,7 @@ export const Label = styled.label`
     color: #fff;
 `;
 
-const twists: EpisodeType[] = [DoubleEviction, TripleEvictionCad, TripleEvictionUs];
+const twists: EpisodeType[] = [DoubleEviction, TripleEvictionCad, TripleEvictionUs, InstantEviction];
 
 const submit = async (jury: number): Promise<void> => {
     season$.next(getEpisodeLibrary());

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -7,7 +7,7 @@ import { cast$, newEpisode, pushToMainContentStream } from "../../subjects/subje
 import { Box } from "../layout/box";
 import { HasText } from "../layout/text";
 import { shuffle } from "lodash";
-import { Screens } from "../topbar/topBar";
+import { activeScreen$, Screens } from "../topbar/topBar";
 interface SidebarState {
     episodes: Episode[];
     selectedScene: number;
@@ -52,7 +52,9 @@ export class Sidebar extends React.Component<{}, SidebarState> {
         );
         newEpisode(episode);
         cast$.next(allBBs);
-        pushToMainContentStream(episode.render, Screens.Other);
+        if (activeScreen$.value === Screens.Other) {
+            pushToMainContentStream(episode.render, Screens.Other);
+        }
     }
 
     public componentWillUnmount() {

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -3,13 +3,15 @@ import { SidebarController } from "./sidebarController";
 import { PregameEpisode } from "../episode/pregameEpisode";
 import { defaultJurySize, Episode, GameState, PlayerProfile } from "../../model";
 import { Scene } from "../episode/scenes/scene";
-import { cast$, mainContentStream$, newEpisode } from "../../subjects/subjects";
+import { cast$, newEpisode, pushToMainContentStream } from "../../subjects/subjects";
 import { Box } from "../layout/box";
 import { HasText } from "../layout/text";
 import { shuffle } from "lodash";
+import { Screens } from "../topbar/topBar";
 interface SidebarState {
     episodes: Episode[];
     selectedScene: number;
+    selectionsActive: boolean;
 }
 const baseUrl = "https://spaulmark.github.io/img/";
 
@@ -20,9 +22,10 @@ export class Sidebar extends React.Component<{}, SidebarState> {
     public constructor(props: {}) {
         super(props);
         this.controller = new SidebarController(this);
-        this.state = { episodes: [], selectedScene: 0 };
+        this.state = { episodes: [], selectedScene: 0, selectionsActive: true };
     }
     public async componentDidMount() {
+        // TODO: this gonna get totally rewritten into a precomputed whitelist.json, first thing next update
         document.addEventListener("keydown", this.controller.handleKeyDown);
         if (!firstLoad) {
             firstLoad = false;
@@ -49,7 +52,7 @@ export class Sidebar extends React.Component<{}, SidebarState> {
         );
         newEpisode(episode);
         cast$.next(allBBs);
-        mainContentStream$.next(episode.render);
+        pushToMainContentStream(episode.render, Screens.Other);
     }
 
     public componentWillUnmount() {
@@ -65,7 +68,7 @@ export class Sidebar extends React.Component<{}, SidebarState> {
     }
 
     private getHighlight(title: string, key: number) {
-        if (key === this.state.selectedScene) {
+        if (key === this.state.selectedScene && this.state.selectionsActive) {
             return <mark>{title}</mark>;
         }
         return title;

--- a/src/components/topbar/themeSwitch.tsx
+++ b/src/components/topbar/themeSwitch.tsx
@@ -1,7 +1,3 @@
-import React, { useState } from "react";
-import { theme$ } from "../../subjects/subjects";
-import { darkTheme } from "../../theme/theme";
-
 // this class is temporarily unused, but in the future it will be used for custom themes
 // export function ThemeSwitcher() {
 //     const [theme, setTheme] = useState(

--- a/src/components/topbar/topBar.tsx
+++ b/src/components/topbar/topBar.tsx
@@ -7,7 +7,7 @@ import { Box } from "../layout/box";
 import { DeckScreen } from "../deckScreen/deckScreen";
 import { SeasonEditorPage } from "../seasonEditor/seasonEditorPage";
 
-const TopbarLink = styled.div`
+export const TopbarLink = styled.a`
     color: ${({ theme }: { theme: ColorTheme }) => theme.link};
     cursor: pointer;
 `;

--- a/src/subjects/subjects.tsx
+++ b/src/subjects/subjects.tsx
@@ -6,9 +6,16 @@ import React from "react";
 import { PortraitDisplayMode, popularityMode } from "../model/portraitDisplayMode";
 import { ColorTheme } from "../theme/theme";
 import { EpisodeLibrary } from "../model/season";
+import { activeScreen$, Screens } from "../components/topbar/topBar";
 
 // What is currently being displayed.
 export const mainContentStream$ = new BehaviorSubject(<PregameScreen cast={[]} />);
+
+export function pushToMainContentStream(content: JSX.Element, tab?: Screens) {
+    tab && activeScreen$.next(tab);
+    mainContentStream$.next(content);
+}
+
 // Push episodes to this subject to add them to the sidebar. Null resets everything.
 export const episodes$ = new BehaviorSubject<Episode | null>(null);
 // Forcibly switches to an episode. Used when adding a new episode.


### PR DESCRIPTION

New Twists:

- Added Instant Evictions

Cast updates:

- New Cast: Skullgirls
- New Cast: Uma Musume
- New Cast: Scandanavia and the World (Contributed by @domasan12#2527)
- New Casts: Big Brother Canada 1-6
- New Casts: Big Brother 1-7
- Updated Cast: Mahjong Soul
- Updated Cast: Genshin Impact
- Updated Cast: SCP Foundation
- Updated Cast: Brazillian Soccer Mascots (Updated by @domasan12#2527)
- Updated Cast: Digimon Tamers (Updated by @KeitaroMorikawa#4189)
- Updated Cast: Digimon (Updated by @KeitaroMorikawa#4189)
- Deleted duplicate cast: Ty the Tasmianian Tiger (vs. Ty the Tasmanian Tiger) (note the extra "i")

Various QOL Improvements:

- Added a tooltip to the random button indicating that selected cast members will always be chosen
- Change continue to Start Game on the home page
- Add a description/short tutorial of what bb-bots is and does on the home page
- There is now a visual indicator for what screen you are currently on during game setup

Bugfixes:
 
- Fixed a visual bug where double evictions were not displaying the eviction scene as intended
- Fixed a bug where you could select houseguests pregame by clicking on them in the pregame screen
- You can no longer use the arrow keys to move between episodes when you are on the choose cast, edit/upload cast, or edit season screens
- In triple evictions, the evictee that recieves the second most votes will place higher than the evictee who recieves the third most votes
- Fixed a bug where if you went away from the pregame screen while it was still loading the default cast, it would snap you back to the pregame screen when the default cast loaded