### PR TITLE
Veto update

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,6 @@
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>
-        <script async src="https://static.getclicky.com/101359694.js"></script>
         <div id="root"></div>
     </body>
 </html>

--- a/src/components/deckScreen/deckScreen.tsx
+++ b/src/components/deckScreen/deckScreen.tsx
@@ -17,7 +17,9 @@ interface DeckScreenState {
     loading: boolean;
     decks: string[];
     i: number;
+    sortedDecks: string[];
     debouncedSearchText: string;
+    isSorted: boolean;
     searchText: string;
     selectedDecks: Set<string>;
 }
@@ -119,8 +121,10 @@ export class DeckScreen extends React.Component<DeckScreenProps, DeckScreenState
         this.state = {
             loading: true,
             decks: [],
+            sortedDecks: [],
             selectedDecks: new Set<string>(),
             i: 0,
+            isSorted: false,
             debouncedSearchText: "",
             searchText: "",
         };
@@ -129,7 +133,12 @@ export class DeckScreen extends React.Component<DeckScreenProps, DeckScreenState
         selectDeckSubject(null);
         this.subs.push(selectedDecks$.subscribe((selectedDecks) => this.setState({ selectedDecks })));
         const data = await (await fetch("https://spaulmark.github.io/img/dir.json")).json();
-        this.setState({ decks: shuffle(data.decks), selectedDecks: new Set<string>(), loading: false });
+        this.setState({
+            sortedDecks: data.decks,
+            decks: shuffle(data.decks),
+            selectedDecks: new Set<string>(),
+            loading: false,
+        });
     }
     componentWillUnmount() {
         this.subs.forEach((sub) => sub.unsubscribe());
@@ -150,7 +159,7 @@ export class DeckScreen extends React.Component<DeckScreenProps, DeckScreenState
 
     render() {
         if (this.state.loading) return <div />;
-        const decks = this.state.decks.filter((deck) =>
+        const decks = (this.state.isSorted ? this.state.sortedDecks : this.state.decks).filter((deck) =>
             deck.toLowerCase().match(this.state.debouncedSearchText.toLowerCase())
         );
         return (
@@ -166,6 +175,15 @@ export class DeckScreen extends React.Component<DeckScreenProps, DeckScreenState
                             value={this.state.searchText}
                         ></input>
                     </div>
+                    <div className="level-item">
+                        <button
+                            className={`button ${this.state.isSorted ? "is-danger" : "is-primary"}`}
+                            onClick={() => this.setState({ isSorted: !this.state.isSorted })}
+                        >
+                            A/Z
+                        </button>
+                    </div>
+
                     <div className="level-item">
                         <button
                             className="button is-warning"

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -123,7 +123,8 @@ export function generateBBVanillaScenes(
             hoh,
             nominees,
             povWinner,
-            doubleEviction
+            doubleEviction,
+            veto
         );
         scenes.push(vetoCeremonyScene);
     }

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -123,7 +123,7 @@ export function generateBBVanillaScenes(
             hoh,
             nominees,
             povWinner,
-            { doubleEviction, finalNominees: 2 }
+            doubleEviction
         );
         scenes.push(vetoCeremonyScene);
     }

--- a/src/components/episode/diamondVetoEpisode.tsx
+++ b/src/components/episode/diamondVetoEpisode.tsx
@@ -1,0 +1,24 @@
+import { GameState } from "../../model";
+import { generateBBVanillaScenes } from "./bigBrotherEpisode";
+import { EpisodeType, Episode } from "./episodes";
+import { DiamondVeto } from "./veto/veto";
+
+export const DiamondVetoEpisode: EpisodeType = {
+    canPlayWith: (n: number) => n >= 4,
+    eliminates: 1,
+    arrowsEnabled: true,
+    hasViewsbar: true,
+    name: "💎 Diamond Veto",
+    generate: generateNoVeto,
+};
+
+function generateNoVeto(initialGamestate: GameState): Episode {
+    const episode = generateBBVanillaScenes(initialGamestate, DiamondVeto);
+    return new Episode({
+        gameState: new GameState(episode.gameState),
+        initialGamestate,
+        title: episode.title,
+        scenes: episode.scenes,
+        type: DiamondVetoEpisode,
+    });
+}

--- a/src/components/episode/doubleEvictionEpisode.tsx
+++ b/src/components/episode/doubleEvictionEpisode.tsx
@@ -10,7 +10,7 @@ export const DoubleEviction: EpisodeType = {
     eliminates: 2,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "Double Eviction",
+    name: "⏩ Double Eviction",
     generate: generateDoubleEviction,
 };
 

--- a/src/components/episode/forcedVetoEpisode.tsx
+++ b/src/components/episode/forcedVetoEpisode.tsx
@@ -4,7 +4,7 @@ import { EpisodeType, Episode } from "./episodes";
 import { SpotlightVeto } from "./veto/veto";
 
 export const ForcedVetoEpisode: EpisodeType = {
-    canPlayWith: (n: number) => n >= 5,
+    canPlayWith: (n: number) => n >= 4,
     eliminates: 1,
     arrowsEnabled: true,
     hasViewsbar: true,
@@ -13,7 +13,7 @@ export const ForcedVetoEpisode: EpisodeType = {
 };
 
 function generateForcedVeto(initialGamestate: GameState): Episode {
-    const episode = generateBBVanillaScenes(initialGamestate, SpotlightVeto); // TODO: make this do something, non-nom doesnt win in f4
+    const episode = generateBBVanillaScenes(initialGamestate, SpotlightVeto);
     return new Episode({
         gameState: new GameState(episode.gameState),
         initialGamestate,

--- a/src/components/episode/forcedVetoEpisode.tsx
+++ b/src/components/episode/forcedVetoEpisode.tsx
@@ -1,0 +1,24 @@
+import { GameState } from "../../model";
+import { generateBBVanillaScenes } from "./bigBrotherEpisode";
+import { EpisodeType, Episode } from "./episodes";
+import { SpotlightVeto } from "./veto/veto";
+
+export const ForcedVetoEpisode: EpisodeType = {
+    canPlayWith: (n: number) => n >= 5,
+    eliminates: 1,
+    arrowsEnabled: true,
+    hasViewsbar: true,
+    name: "🔦 Forced Veto",
+    generate: generateForcedVeto,
+};
+
+function generateForcedVeto(initialGamestate: GameState): Episode {
+    const episode = generateBBVanillaScenes(initialGamestate, SpotlightVeto); // TODO: make this do something, non-nom doesnt win in f4
+    return new Episode({
+        gameState: new GameState(episode.gameState),
+        initialGamestate,
+        title: episode.title,
+        scenes: episode.scenes,
+        type: ForcedVetoEpisode,
+    });
+}

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -10,7 +10,7 @@ export const InstantEviction: EpisodeType = {
     eliminates: 2,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "Instant Eviction",
+    name: "⚡ Instant Eviction",
     generate: generateInstantEviction,
 };
 

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { GameState } from "../../model";
 import { generateBBVanillaScenes } from "./bigBrotherEpisode";
-import { DoubleEviction } from "./doubleEvictionEpisode";
 import { EpisodeType, Episode } from "./episodes";
 import { Scene } from "./scenes/scene";
 import { GoldenVeto } from "./veto/veto";
@@ -37,6 +36,6 @@ function generateInstantEviction(initialGamestate: GameState): Episode {
         initialGamestate,
         title: episode.title,
         scenes,
-        type: DoubleEviction,
+        type: InstantEviction,
     });
 }

--- a/src/components/episode/noVetoEpisode.tsx
+++ b/src/components/episode/noVetoEpisode.tsx
@@ -1,6 +1,5 @@
 import { GameState } from "../../model";
 import { generateBBVanillaScenes } from "./bigBrotherEpisode";
-import { DoubleEviction } from "./doubleEvictionEpisode";
 import { EpisodeType, Episode } from "./episodes";
 
 export const NoVeto: EpisodeType = {
@@ -19,6 +18,6 @@ function generateNoVeto(initialGamestate: GameState): Episode {
         initialGamestate,
         title: episode.title,
         scenes: episode.scenes,
-        type: DoubleEviction,
+        type: NoVeto,
     });
 }

--- a/src/components/episode/noVetoEpisode.tsx
+++ b/src/components/episode/noVetoEpisode.tsx
@@ -1,0 +1,24 @@
+import { GameState } from "../../model";
+import { generateBBVanillaScenes } from "./bigBrotherEpisode";
+import { DoubleEviction } from "./doubleEvictionEpisode";
+import { EpisodeType, Episode } from "./episodes";
+
+export const NoVeto: EpisodeType = {
+    canPlayWith: (n: number) => n >= 4,
+    eliminates: 1,
+    arrowsEnabled: true,
+    hasViewsbar: true,
+    name: "No Veto",
+    generate: generateNoVeto,
+};
+
+function generateNoVeto(initialGamestate: GameState): Episode {
+    const episode = generateBBVanillaScenes(initialGamestate, null);
+    return new Episode({
+        gameState: new GameState(episode.gameState),
+        initialGamestate,
+        title: episode.title,
+        scenes: episode.scenes,
+        type: DoubleEviction,
+    });
+}

--- a/src/components/episode/noVetoEpisode.tsx
+++ b/src/components/episode/noVetoEpisode.tsx
@@ -7,7 +7,7 @@ export const NoVeto: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "No Veto",
+    name: "🚫 No Veto",
     generate: generateNoVeto,
 };
 

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -9,19 +9,13 @@ import { DividerBox } from "../../layout/box";
 import { listNames } from "../../../utils/listStrings";
 import _ from "lodash";
 
-interface VetoCeremonyOptions {
-    doubleEviction: boolean;
-    finalNominees: number; // TODO: this does nothing, replace with nameReplacement? / forceUse? idk.
-}
-
 export function generateVetoCeremonyScene(
     initialGameState: GameState,
     HoH: Houseguest,
     initialNominees: Houseguest[],
     povWinner: Houseguest,
-    options: VetoCeremonyOptions
+    doubleEviction: boolean
 ): [GameState, Scene, Houseguest[]] {
-    const doubleEviction = options.doubleEviction;
     let povTarget: Houseguest | null = null;
     let descisionText = "";
 

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -47,7 +47,9 @@ export function generateVetoCeremonyScene(
         const HoHwonPoV = HoH.id === povWinner.id;
         nameAReplacement += HoHwonPoV
             ? `Since I have just vetoed one of my nominations, I must name a replacement nominee.`
-            : `${HoH.name}, since I have just vetoed one of your nominations, you must name a replacement nominee.`;
+            : `${HoH.name}, since I have just vetoed one of your nominations, ${
+                  veto === DiamondVeto ? "I" : "you"
+              } must name a replacement nominee.`;
         const replacementNom = {
             ...getById(
                 initialGameState,

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -25,7 +25,8 @@ export function generateVetoCeremonyScene(
         return getById(initialGameState, nominee.id);
     });
     HoH = getById(initialGameState, HoH.id);
-    const vetoChoice = useGoldenVeto(povWinner, initialNominees, initialGameState, HoH.id);
+
+    const vetoChoice = veto.use(povWinner, initialNominees, initialGameState, HoH.id);
 
     let nomineeWonPov = false;
     initialNominees.forEach((nom) => nom.id === povWinner.id && (nomineeWonPov = true));

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -50,19 +50,19 @@ export function generateVetoCeremonyScene(
             : `${HoH.name}, since I have just vetoed one of your nominations, ${
                   veto === DiamondVeto ? "I" : "you"
               } must name a replacement nominee.`;
+        // if the exclusion yielded no options, you may be forced to name the veto winner as a replacement
+        let exclusion = exclude(initialGameState.houseguests, [
+            replacementNomineeNamer,
+            ...initialNominees,
+            povWinner,
+        ]);
+        if (exclusion.length === 0) {
+            exclusion = exclude(initialGameState.houseguests, [replacementNomineeNamer, ...initialNominees]);
+        }
         const replacementNom = {
             ...getById(
                 initialGameState,
-                backdoorNPlayers(
-                    replacementNomineeNamer,
-                    exclude(initialGameState.houseguests, [
-                        replacementNomineeNamer,
-                        ...initialNominees,
-                        povWinner,
-                    ]),
-                    initialGameState,
-                    1
-                )[0].decision
+                backdoorNPlayers(replacementNomineeNamer, exclusion, initialGameState, 1)[0].decision
             ),
         };
         const replacementIndex = initialNominees.findIndex((hg) => hg.id === vetoChoice.decision!.id);

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -1,6 +1,6 @@
 import { GameState, Houseguest, getById, exclude } from "../../../model";
 import { Scene } from "./scene";
-import { useGoldenVeto, backdoorNPlayers } from "../../../utils/ai/aiApi";
+import { backdoorNPlayers } from "../../../utils/ai/aiApi";
 import { Portrait } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -51,13 +51,9 @@ export function generateVetoCeremonyScene(
                   veto === DiamondVeto ? "I" : "you"
               } must name a replacement nominee.`;
         // if the exclusion yielded no options, you may be forced to name the veto winner as a replacement
-        let exclusion = exclude(initialGameState.houseguests, [
-            replacementNomineeNamer,
-            ...initialNominees,
-            povWinner,
-        ]);
+        let exclusion = exclude(initialGameState.houseguests, [HoH, ...initialNominees, povWinner]);
         if (exclusion.length === 0) {
-            exclusion = exclude(initialGameState.houseguests, [replacementNomineeNamer, ...initialNominees]);
+            exclusion = exclude(initialGameState.houseguests, [HoH, ...initialNominees]);
         }
         const replacementNom = {
             ...getById(

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -8,13 +8,15 @@ import { Centered, CenteredBold } from "../../layout/centered";
 import { DividerBox } from "../../layout/box";
 import { listNames } from "../../../utils/listStrings";
 import _ from "lodash";
+import { DiamondVeto, Veto } from "../veto/veto";
 
 export function generateVetoCeremonyScene(
     initialGameState: GameState,
     HoH: Houseguest,
     initialNominees: Houseguest[],
     povWinner: Houseguest,
-    doubleEviction: boolean
+    doubleEviction: boolean,
+    veto: Veto
 ): [GameState, Scene, Houseguest[]] {
     let povTarget: Houseguest | null = null;
     let descisionText = "";
@@ -39,6 +41,7 @@ export function generateVetoCeremonyScene(
     let replacementSpeech = "";
     let nameAReplacement = "";
     let finalNominees: any[] = [...initialNominees];
+    const replacementNomineeNamer = veto === DiamondVeto ? povWinner : HoH;
     if (povTarget) {
         const HoHwonPoV = HoH.id === povWinner.id;
         nameAReplacement += HoHwonPoV
@@ -48,8 +51,12 @@ export function generateVetoCeremonyScene(
             ...getById(
                 initialGameState,
                 backdoorNPlayers(
-                    HoH,
-                    exclude(initialGameState.houseguests, [HoH, ...initialNominees, povWinner]),
+                    replacementNomineeNamer,
+                    exclude(initialGameState.houseguests, [
+                        replacementNomineeNamer,
+                        ...initialNominees,
+                        povWinner,
+                    ]),
                     initialGameState,
                     1
                 )[0].decision
@@ -87,7 +94,7 @@ export function generateVetoCeremonyScene(
                 <Portrait centered={true} houseguest={{ ...povWinner, tooltip: vetoChoice.reason }} />
                 <CenteredBold noMargin={true}>{descisionText}</CenteredBold>
                 <Centered>{nameAReplacement}</Centered>
-                {replacementSpeech && <Portrait centered={true} houseguest={HoH} />}
+                {replacementSpeech && <Portrait centered={true} houseguest={replacementNomineeNamer} />}
                 <CenteredBold>{replacementSpeech}</CenteredBold>
                 <div className="columns is-marginless is-centered">
                     {finalNominees.map((nom, i) => (

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -60,7 +60,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
         hoh,
         nominees,
         povWinner,
-        { doubleEviction: true, finalNominees: 3 }
+        true
     );
     tripleScenes.push(vetoCeremonyScene);
 

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -60,7 +60,8 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
         hoh,
         nominees,
         povWinner,
-        true
+        true,
+        GoldenVeto
     );
     tripleScenes.push(vetoCeremonyScene);
 

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -14,7 +14,7 @@ export const TripleEvictionCad: EpisodeType = {
     eliminates: 3,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "Triple Eviction 🇨🇦",
+    name: "🇨🇦 Triple Eviction",
     generate: generateTripleEvictionCad,
 };
 

--- a/src/components/episode/tripleEvictionEpisodeUs.tsx
+++ b/src/components/episode/tripleEvictionEpisodeUs.tsx
@@ -9,7 +9,7 @@ export const TripleEvictionUs: EpisodeType = {
     eliminates: 3,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "Triple Eviction 🇺🇸",
+    name: "🇺🇸 Triple Eviction",
     generate: generateTripleEvictionUs,
 };
 

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -1,11 +1,24 @@
+import { Houseguest, GameState } from "../../../model";
+import { HouseguestWithLogic, useDiamondVeto, useGoldenVeto } from "../../../utils/ai/aiApi";
+
 export interface Veto {
     name: string;
+    use: (hero: Houseguest, nominees: Houseguest[], gameState: GameState, HoH: number) => HouseguestWithLogic;
 }
 
 export const GoldenVeto: Veto = {
     name: "Golden Power of Veto",
+    use: useGoldenVeto,
 };
 
 export const DiamondVeto: Veto = {
     name: "Diamond Power of Veto",
+    use: useDiamondVeto,
+};
+
+export const SpotlightVeto: Veto = {
+    name: "Spotlight Power of Veto",
+    use: (hero: Houseguest, nominees: Houseguest[], gameState: GameState, HoH: number) => {
+        throw new Error("Not implemented");
+    },
 };

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -18,7 +18,7 @@ export const DiamondVeto: Veto = {
 
 export const SpotlightVeto: Veto = {
     name: "Spotlight Power of Veto",
-    use: (hero: Houseguest, nominees: Houseguest[], gameState: GameState, HoH: number) => {
+    use: (_hero: Houseguest, _nominees: Houseguest[], _gameState: GameState, _HoH: number) => {
         throw new Error("Not implemented");
     },
 };

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -1,5 +1,7 @@
-import { Houseguest, GameState } from "../../../model";
-import { HouseguestWithLogic, useDiamondVeto, useGoldenVeto } from "../../../utils/ai/aiApi";
+import { Houseguest, GameState, exclude, getById, nonEvictedHouseguests } from "../../../model";
+import { backdoorNPlayers, HouseguestWithLogic, NumberWithLogic } from "../../../utils/ai/aiApi";
+import { classifyRelationship, RelationshipType } from "../../../utils/ai/classifyRelationship";
+import { isBetterTarget, getRelationshipSummary } from "../../../utils/ai/targets";
 
 export interface Veto {
     name: string;
@@ -22,3 +24,107 @@ export const SpotlightVeto: Veto = {
         throw new Error("Not implemented");
     },
 };
+
+function useGoldenVetoPreJury(
+    hero: Houseguest,
+    nominees: Houseguest[],
+    gameState: GameState
+): HouseguestWithLogic {
+    let reason = "None of these nominees are my friends.";
+    let potentialSave: Houseguest | null = null;
+    let alwaysSave: Houseguest | null = null;
+    nominees.forEach((nominee) => {
+        // TODO: Save people who you can beat in the end if you are low winrate
+        const relationship = classifyRelationship(
+            hero.popularity,
+            nominee.popularity,
+            hero.relationshipWith(nominee)
+        );
+        if (relationship === RelationshipType.Friend) {
+            if (potentialSave) {
+                potentialSave =
+                    hero.relationshipWith(nominee) > hero.relationshipWith(potentialSave)
+                        ? nominee
+                        : potentialSave;
+                reason = `Of these noms, I like ${potentialSave.name} the most.`;
+            } else {
+                reason = `${nominee.name} is my friend.`;
+                potentialSave = nominee;
+            }
+        }
+    });
+    if (alwaysSave) {
+        return { decision: alwaysSave, reason };
+    } else if (potentialSave) {
+        return { decision: potentialSave, reason };
+    } else {
+        return { decision: null, reason };
+    }
+}
+function useGoldenVeto(
+    hero: Houseguest,
+    nominees: Houseguest[],
+    gameState: GameState,
+    HoH: number
+): HouseguestWithLogic {
+    const checks = basicVetoChecks(hero, nominees, gameState, HoH);
+    if (checks) return checks;
+
+    return useGoldenVetoPreJury(hero, nominees, gameState) || null;
+}
+
+// only works with 2 nominees
+function useDiamondVeto(
+    hero: Houseguest,
+    nominees: Houseguest[],
+    gameState: GameState,
+    HoH: number
+): HouseguestWithLogic {
+    const checks = basicVetoChecks(hero, nominees, gameState, HoH);
+    if (checks) return checks;
+
+    // get the 2 best targets out of the pool of all options
+    const idealTargets: NumberWithLogic[] = backdoorNPlayers(
+        hero,
+        exclude(nonEvictedHouseguests(gameState), [hero, getById(gameState, HoH)]),
+        gameState,
+        2
+    );
+    // if ideal targets is equal to nominees, do nothing
+    const ids1 = idealTargets.map((n) => n.decision);
+    const ids2 = nominees.map((n) => n.id);
+    if ((ids1[0] === ids2[0] && ids1[1] === ids2[1]) || (ids1[0] === ids2[1] && ids1[1] === ids2[0])) {
+        return {
+            decision: null,
+            reason: "These are my ideal nominations.",
+        };
+    }
+    // otherwise, replace the person i least want gone
+    const worseTarget: number = isBetterTarget(
+        getRelationshipSummary(hero, nominees[0]),
+        getRelationshipSummary(hero, nominees[1]),
+        hero,
+        gameState
+    )
+        ? 0
+        : 1;
+
+    return { decision: nominees[worseTarget], reason: "I would rather see someone else nominated." };
+}
+
+function basicVetoChecks(hero: Houseguest, nominees: Houseguest[], gameState: GameState, HoH: number) {
+    if (hero.id === HoH) {
+        return { decision: null, reason: "I support my original nominations." };
+    }
+    for (const nom of nominees) {
+        if (hero.id === nom.id) return { decision: hero, reason: "I am going to save myself." };
+    }
+    // if you're not nominated, don't use the veto if you are the only replacement nominee
+    if (gameState.remainingPlayers - 1 - nominees.length === 1) {
+        return {
+            decision: null,
+            reason: "It doesn't make sense to use the veto here.",
+        };
+    }
+    return null;
+}

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -1,8 +1,11 @@
 export interface Veto {
     name: string;
-    // TODO: something like GenerateScenes() that returns veto comp scene
 }
 
 export const GoldenVeto: Veto = {
     name: "Golden Power of Veto",
+};
+
+export const DiamondVeto: Veto = {
+    name: "Diamond Power of Veto",
 };

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -6,6 +6,7 @@ import { NumericInput } from "../castingScreen/numericInput";
 import { DoubleEviction } from "../episode/doubleEvictionEpisode";
 import { EpisodeType } from "../episode/episodes";
 import { InstantEviction } from "../episode/instantEvictionEpisode";
+import { NoVeto } from "../episode/noVetoEpisode";
 import { PregameEpisode } from "../episode/pregameEpisode";
 import { TripleEvictionCad } from "../episode/tripleEvictionEpisodeCad";
 import { TripleEvictionUs } from "../episode/tripleEvictionEpisodeUs";
@@ -26,7 +27,7 @@ export const Label = styled.label`
     color: #fff;
 `;
 
-const twists: EpisodeType[] = [DoubleEviction, TripleEvictionCad, TripleEvictionUs, InstantEviction];
+const twists: EpisodeType[] = [DoubleEviction, TripleEvictionCad, TripleEvictionUs, InstantEviction, NoVeto];
 
 const submit = async (jury: number): Promise<void> => {
     season$.next(getEpisodeLibrary());

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { defaultJurySize, GameState, validateJurySize } from "../../model/gameState";
 import { cast$, newEpisode, pushToMainContentStream, season$ } from "../../subjects/subjects";
 import { NumericInput } from "../castingScreen/numericInput";
+import { DiamondVetoEpisode } from "../episode/diamondVetoEpisode";
 import { DoubleEviction } from "../episode/doubleEvictionEpisode";
 import { EpisodeType } from "../episode/episodes";
 import { InstantEviction } from "../episode/instantEvictionEpisode";
@@ -27,7 +28,16 @@ export const Label = styled.label`
     color: #fff;
 `;
 
-const twists: EpisodeType[] = [DoubleEviction, TripleEvictionCad, TripleEvictionUs, InstantEviction, NoVeto];
+// TODO: forced pov,
+
+const twists: EpisodeType[] = [
+    DoubleEviction,
+    TripleEvictionCad,
+    TripleEvictionUs,
+    InstantEviction,
+    NoVeto,
+    DiamondVetoEpisode,
+];
 
 const submit = async (jury: number): Promise<void> => {
     season$.next(getEpisodeLibrary());

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -6,6 +6,7 @@ import { NumericInput } from "../castingScreen/numericInput";
 import { DiamondVetoEpisode } from "../episode/diamondVetoEpisode";
 import { DoubleEviction } from "../episode/doubleEvictionEpisode";
 import { EpisodeType } from "../episode/episodes";
+import { ForcedVetoEpisode } from "../episode/forcedVetoEpisode";
 import { InstantEviction } from "../episode/instantEvictionEpisode";
 import { NoVeto } from "../episode/noVetoEpisode";
 import { PregameEpisode } from "../episode/pregameEpisode";
@@ -28,7 +29,7 @@ export const Label = styled.label`
     color: #fff;
 `;
 
-// TODO: forced pov,
+// TODO: boomerang veto, double veto.
 
 const twists: EpisodeType[] = [
     DoubleEviction,
@@ -37,6 +38,7 @@ const twists: EpisodeType[] = [
     InstantEviction,
     NoVeto,
     DiamondVetoEpisode,
+    ForcedVetoEpisode,
 ];
 
 const submit = async (jury: number): Promise<void> => {

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -147,7 +147,7 @@ export function backdoorNPlayers(
 
     while (result.length < n) {
         const decision = sortedOptions[result.length];
-        const reason = "I think you are ugly";
+        const reason = "";
         result.push({ decision: decision.id, reason });
     }
     return result;

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -103,42 +103,42 @@ function castF4vote(hero: Houseguest, nom0: Houseguest, nom1: Houseguest, HoH: H
     };
 }
 
-function cutthroatVoteJury(hero: Houseguest, nominees: Houseguest[], gameState: GameState): NumberWithLogic {
-    const nom0 = nominees[0];
-    const nom1 = nominees[1];
-    // In the F3 vote, take the person who you have better odds against to F2
-    if (gameState.remainingPlayers === 3) {
-        return castF3Vote(hero, nom0, nom1);
-    }
-    // In the F4 vote, do some genius level mathematics to predict what gives you the best odds of winning given that the
-    // person who wins the F3 HoH will evict the person they have the worst odds against
-    if (gameState.remainingPlayers === 4) {
-        return castF4vote(
-            hero,
-            nom0,
-            nom1,
-            // all this work just to get the HoH...
-            exclude(
-                Array.from(gameState.nonEvictedHouseguests.values()).map(
-                    (id) => gameState.houseguestCache[id]
-                ),
-                [nom0, nom1, hero]
-            )[0]
-        );
-    }
-    if (hero.powerRanking >= 0.45) {
-        // with a high enough winrate, vote normally
-        // return cutthroatVote(hero, nominees);
-    } else if (hero.powerRanking <= 1 / 3) {
-        // with a very low winrate, vote based on winrate
-        // return voteBasedOnWinrate();
-    } else {
-        // with a sort of low winrate, break ties with winrate
-        const r0 = classifyTwoWayRelationship(hero.popularity, nom0.popularity, hero.relationships[nom0.id]);
-        const r1 = classifyTwoWayRelationship(hero.popularity, nom1.popularity, hero.relationships[nom1.id]);
-        return r0 === r1 ? voteBasedOnWinrate() : cutthroatVote(hero, nominees);
-    }
-}
+// function cutthroatVoteJury(hero: Houseguest, nominees: Houseguest[], gameState: GameState): NumberWithLogic {
+//     const nom0 = nominees[0];
+//     const nom1 = nominees[1];
+//     // In the F3 vote, take the person who you have better odds against to F2
+//     if (gameState.remainingPlayers === 3) {
+//         return castF3Vote(hero, nom0, nom1);
+//     }
+//     // In the F4 vote, do some genius level mathematics to predict what gives you the best odds of winning given that the
+//     // person who wins the F3 HoH will evict the person they have the worst odds against
+//     if (gameState.remainingPlayers === 4) {
+//         return castF4vote(
+//             hero,
+//             nom0,
+//             nom1,
+//             // all this work just to get the HoH...
+//             exclude(
+//                 Array.from(gameState.nonEvictedHouseguests.values()).map(
+//                     (id) => gameState.houseguestCache[id]
+//                 ),
+//                 [nom0, nom1, hero]
+//             )[0]
+//         );
+//     }
+//     if (hero.powerRanking >= 0.45) {
+//         // with a high enough winrate, vote normally
+//         // return cutthroatVote(hero, nominees);
+//     } else if (hero.powerRanking <= 1 / 3) {
+//         // with a very low winrate, vote based on winrate
+//         // return voteBasedOnWinrate();
+//     } else {
+//         // with a sort of low winrate, break ties with winrate
+//         const r0 = classifyTwoWayRelationship(hero.popularity, nom0.popularity, hero.relationships[nom0.id]);
+//         const r1 = classifyTwoWayRelationship(hero.popularity, nom1.popularity, hero.relationships[nom1.id]);
+//         return r0 === r1 ? voteBasedOnWinrate() : cutthroatVote(hero, nominees);
+//     }
+// }
 
 // only works for 2 nominees
 

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -1,6 +1,5 @@
-import { Houseguest, GameState, exclude, getById, nonEvictedHouseguests } from "../../model";
+import { Houseguest, GameState, exclude } from "../../model";
 import { rng } from "../BbRandomGenerator";
-import { classifyRelationship, RelationshipType as Relationship } from "./classifyRelationship";
 import { getRelationshipSummary, isBetterTarget, isBetterTargetWithLogic } from "./targets";
 
 export interface NumberWithLogic {
@@ -143,111 +142,6 @@ export function backdoorNPlayers(
         result.push({ decision: decision.id, reason });
     }
     return result;
-}
-
-function basicVetoChecks(hero: Houseguest, nominees: Houseguest[], gameState: GameState, HoH: number) {
-    if (hero.id === HoH) {
-        return { decision: null, reason: "I support my original nominations." };
-    }
-    for (const nom of nominees) {
-        if (hero.id === nom.id) return { decision: hero, reason: "I am going to save myself." };
-    }
-    // if you're not nominated, don't use the veto if you are the only replacement nominee
-    if (gameState.remainingPlayers - 1 - nominees.length === 1) {
-        return {
-            decision: null,
-            reason: "It doesn't make sense to use the veto here.",
-        };
-    }
-    return null;
-}
-
-export function useGoldenVeto(
-    hero: Houseguest,
-    nominees: Houseguest[],
-    gameState: GameState,
-    HoH: number
-): HouseguestWithLogic {
-    const checks = basicVetoChecks(hero, nominees, gameState, HoH);
-    if (checks) return checks;
-
-    return useGoldenVetoPreJury(hero, nominees, gameState) || null;
-}
-
-// only works with 2 nominees
-export function useDiamondVeto(
-    hero: Houseguest,
-    nominees: Houseguest[],
-    gameState: GameState,
-    HoH: number
-): HouseguestWithLogic {
-    const checks = basicVetoChecks(hero, nominees, gameState, HoH);
-    if (checks) return checks;
-
-    // get the 2 best targets out of the pool of all options
-    const idealTargets: NumberWithLogic[] = backdoorNPlayers(
-        hero,
-        exclude(nonEvictedHouseguests(gameState), [hero, getById(gameState, HoH)]),
-        gameState,
-        2
-    );
-    // if ideal targets is equal to nominees, do nothing
-    const ids1 = idealTargets.map((n) => n.decision);
-    const ids2 = nominees.map((n) => n.id);
-    if ((ids1[0] === ids2[0] && ids1[1] === ids2[1]) || (ids1[0] === ids2[1] && ids1[1] === ids2[0])) {
-        return {
-            decision: null,
-            reason: "These are my ideal nominations.",
-        };
-    }
-    // otherwise, replace the person i least want gone
-    const worseTarget: number = isBetterTarget(
-        getRelationshipSummary(hero, nominees[0]),
-        getRelationshipSummary(hero, nominees[1]),
-        hero,
-        gameState
-    )
-        ? 0
-        : 1;
-
-    return { decision: nominees[worseTarget], reason: "I would rather see someone else nominated." };
-}
-
-function useGoldenVetoPreJury(
-    hero: Houseguest,
-    nominees: Houseguest[],
-    gameState: GameState
-): HouseguestWithLogic {
-    let reason = "None of these nominees are my friends.";
-    let potentialSave: Houseguest | null = null;
-    let alwaysSave: Houseguest | null = null;
-    nominees.forEach((nominee) => {
-        // TODO: Save people who you can beat in the end if you are low winrate
-        const relationship = classifyRelationship(
-            hero.popularity,
-            nominee.popularity,
-            hero.relationshipWith(nominee)
-        );
-        if (relationship === Relationship.Friend) {
-            if (potentialSave) {
-                potentialSave =
-                    hero.relationshipWith(nominee) > hero.relationshipWith(potentialSave)
-                        ? nominee
-                        : potentialSave;
-                reason = `Of these noms, I like ${potentialSave.name} the most.`;
-            } else {
-                reason = `${nominee.name} is my friend.`;
-                potentialSave = nominee;
-            }
-        }
-    });
-    if (alwaysSave) {
-        return { decision: alwaysSave, reason };
-    } else if (potentialSave) {
-        return { decision: potentialSave, reason };
-    } else {
-        return { decision: null, reason };
-    }
 }
 
 export function pJurorVotesForHero(juror: Houseguest, hero: Houseguest, villain: Houseguest): number {

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -13,7 +13,7 @@ export interface NumberWithLogic {
     reason: string;
 }
 
-interface HouseguestWithLogic {
+export interface HouseguestWithLogic {
     decision: Houseguest | null;
     reason: string;
 }
@@ -225,12 +225,7 @@ export function backdoorNPlayers(
     return result;
 }
 
-export function useGoldenVeto(
-    hero: Houseguest,
-    nominees: Houseguest[],
-    gameState: GameState,
-    HoH: number
-): HouseguestWithLogic {
+function basicVetoChecks(hero: Houseguest, nominees: Houseguest[], gameState: GameState, HoH: number) {
     if (hero.id === HoH) {
         return { decision: null, reason: "I support my original nominations." };
     }
@@ -244,7 +239,33 @@ export function useGoldenVeto(
             reason: "It doesn't make sense to use the veto here.",
         };
     }
+    return null;
+}
+
+export function useGoldenVeto(
+    hero: Houseguest,
+    nominees: Houseguest[],
+    gameState: GameState,
+    HoH: number
+): HouseguestWithLogic {
+    const checks = basicVetoChecks(hero, nominees, gameState, HoH);
+    if (checks) return checks;
+
     return useGoldenVetoPreJury(hero, nominees, gameState) || null;
+}
+
+export function useDiamondVeto(
+    hero: Houseguest,
+    nominees: Houseguest[],
+    gameState: GameState,
+    HoH: number
+): HouseguestWithLogic {
+    const checks = basicVetoChecks(hero, nominees, gameState, HoH);
+    if (checks) return checks; // TODO: we also need a nominee if you're using it on yourself.
+
+    // if a better target exists in the pool of options, replace the person i least want gone with the person i most want gone.
+    // TODO: just refactor the logic, it will be much easier
+    return { decision: null, reason: "TODO" };
 }
 
 function useGoldenVetoPreJury(

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -1,4 +1,4 @@
-import { Houseguest, GameState, exclude } from "../../model";
+import { Houseguest, GameState, exclude, inJury } from "../../model";
 import { rng } from "../BbRandomGenerator";
 import { getRelationshipSummary, isBetterTarget, isBetterTargetWithLogic } from "./targets";
 
@@ -48,6 +48,15 @@ export function castEvictionVote(
     // In the F4 vote, do some genius level mathematics to predict what gives you the best odds of winning given that the
     // person who wins the F3 HoH will evict the person they have the worst odds against
     if (gameState.remainingPlayers === 4) {
+        // prevents 4 player games from crashing LULW
+        if (!inJury(gameState)) {
+            return isBetterTargetWithLogic(
+                getRelationshipSummary(hero, nominees[0]),
+                getRelationshipSummary(hero, nominees[1]),
+                hero,
+                gameState
+            );
+        }
         return castF4vote(
             hero,
             nominees[0],

--- a/src/utils/ai/aiUtils.ts
+++ b/src/utils/ai/aiUtils.ts
@@ -1,9 +1,9 @@
-import { Houseguest, GameState } from "../../model";
+import { Houseguest } from "../../model";
 import { pbincdf } from "../poissonbinomial";
 import { pJurorVotesForHero } from "./aiApi";
 import { classifyRelationship } from "./classifyRelationship";
 
-export const relationship = (hero: Houseguest, villain: Houseguest) => hero.relationships[villain.id];
+export const relationship = (hero: Houseguest, villain: { id: number }) => hero.relationships[villain.id];
 
 export const RelationshipTypeToNumber = { FRIEND: 10, ENEMY: -10, PAWN: 0, QUEEN: +5 };
 
@@ -39,11 +39,7 @@ function highestScore(
     });
     return highestIndex;
 }
-export function lowestScore(
-    hero: Houseguest,
-    options: Houseguest[],
-    callback: (hero: Houseguest, villain: Houseguest) => number
-) {
+export function lowestScore<H, V>(hero: H, options: V[], callback: (hero: H, villain: V) => number) {
     let lowestIndex = 0;
     let lowestScore = Infinity;
     options.forEach((villain, i) => {

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -114,15 +114,7 @@ export function isBetterTarget(
     gameState: GameState
 ): boolean {
     if (old.relationship === 2) return true;
-    const strategy = determineStrategy(hero);
-    const winrateStrategy = determineWinrateStrategy(hero);
-    if (strategy === TargetStrategy.StatusQuo)
-        return isBetterTargetStatusQuo(hero, old, neww, winrateStrategy).decision === 1;
-    else if (strategy === TargetStrategy.MoR) {
-        return isBetterTargetMoR(old, neww, gameState, hero);
-    } else {
-        return isBetterTargetUnderdog(old, neww, gameState, hero);
-    }
+    return isBetterTargetWithLogic(old, neww, hero, gameState).decision === 1;
 }
 
 function isBetterTargetMoR(
@@ -130,7 +122,9 @@ function isBetterTargetMoR(
     neww: RelationshipSummary,
     gameState: GameState,
     hero: Houseguest
-): boolean {
+): NumberWithLogic {
+    // TODO: somehow we need to take winrates into account here :V
+
     // Is the old target a non-enemy? Then neww is a better target if he is an enemy, or if he's a worse non-enemy.
     if (old.type !== RelationshipType.Enemy) {
         return neww.type === RelationshipType.Enemy ? true : neww.relationship < old.relationship;
@@ -154,7 +148,7 @@ function isBetterTargetUnderdog(
     neww: RelationshipSummary,
     gameState: GameState,
     hero: Houseguest
-): boolean {
+): NumberWithLogic {
     // Is the old target a friend? Then neww is a better target if he is NOT a friend, or if he's a worse friend.
     if (old.type === RelationshipType.Friend) {
         return neww.type !== RelationshipType.Friend ? true : neww.relationship < old.relationship;

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -302,16 +302,16 @@ function voteBasedOnRelationship(
     const r0 = classifyRelationship(hero.popularity, nom0.villainPopularity, hero.relationships[nom0.id]);
     const r1 = classifyRelationship(hero.popularity, nom1.villainPopularity, hero.relationships[nom1.id]);
 
-    const nom0isTarget = hero.targets[0] === nom0.id || hero.targets[1] === nom0.id;
-    const nom1isTarget = hero.targets[0] === nom1.id || hero.targets[1] === nom1.id;
-    // kill targets first
-    if ((nom0isTarget && !nom1isTarget) || (nom1isTarget && !nom0isTarget)) {
-        const decision = nom0isTarget ? 0 : 1;
-        return {
-            decision,
-            reason: `I am targeting ${nominees[decision].villianName}.`,
-        };
-    }
+    // const nom0isTarget = hero.targets[0] === nom0.id || hero.targets[1] === nom0.id;
+    // const nom1isTarget = hero.targets[0] === nom1.id || hero.targets[1] === nom1.id;
+    // // kill targets first
+    // if ((nom0isTarget && !nom1isTarget) || (nom1isTarget && !nom0isTarget)) {
+    //     const decision = nom0isTarget ? 0 : 1;
+    //     return {
+    //         decision,
+    //         reason: `I am targeting ${nominees[decision].villianName}.`,
+    //     };
+    // }
 
     if (r0 === RelationshipType.Enemy && r1 === RelationshipType.Enemy) {
         const decision = hero.relationships[nom0.id] < hero.relationships[nom1.id] ? 0 : 1;

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { GameState, getById, Houseguest } from "../../model";
+import { GameState, getById, Houseguest, inJury } from "../../model";
 import { NumberWithLogic } from "./aiApi";
 import { lowestScore, relationship } from "./aiUtils";
 import { classifyRelationship, classifyTwoWayRelationship, RelationshipType } from "./classifyRelationship";
@@ -98,7 +98,7 @@ export function isBetterTargetWithLogic(
     const strategy = determineStrategy(hero);
     const winrateStrategy = determineWinrateStrategy(hero);
     if (strategy === TargetStrategy.StatusQuo)
-        return isBetterTargetStatusQuo(hero, old, neww, winrateStrategy);
+        return isBetterTargetStatusQuo(hero, old, neww, winrateStrategy, gameState);
     else if (strategy === TargetStrategy.MoR) {
         return isBetterTargetMoR(old, neww, gameState, hero, winrateStrategy);
     } else {
@@ -125,7 +125,7 @@ function isBetterTargetMoR(
 ): NumberWithLogic {
     // TODO: somehow we need to take winrates into account here :V
 
-    if (winrateStrategy === WinrateStrategy.High) {
+    if (winrateStrategy === WinrateStrategy.High || !inJury(gameState)) {
         // prioritize targeting central enemies, break ties based on enemy centrality
     } else if (winrateStrategy === WinrateStrategy.Medium) {
         // prioritize targeting central enemies, break ties based on winrate
@@ -248,9 +248,10 @@ function isBetterTargetStatusQuo(
     hero: Houseguest,
     old: RelationshipSummary,
     neww: RelationshipSummary,
-    winrateStrategy: WinrateStrategy
+    winrateStrategy: WinrateStrategy,
+    gameState: GameState
 ): NumberWithLogic {
-    if (winrateStrategy === WinrateStrategy.High) {
+    if (winrateStrategy === WinrateStrategy.High || !inJury(gameState)) {
         return voteBasedOnRelationship(hero, [old, neww]);
     } else if (winrateStrategy === WinrateStrategy.Medium) {
         // with a sort of low winrate, break ties with winrate

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -90,6 +90,7 @@ function determineStrategy(hero: Houseguest): TargetStrategy {
     return hero.friends > hero.enemies ? TargetStrategy.StatusQuo : TargetStrategy.Underdog;
 }
 
+// return the index of the better target
 export function isBetterTargetWithLogic(
     old: RelationshipSummary,
     neww: RelationshipSummary,

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -16,7 +16,7 @@ interface RelationshipSummary {
 
 const deadValue: RelationshipSummary = {
     type: RelationshipType.Friend,
-    id: -1,
+    id: -123456789, // to make debugging easier :)
     pHeroWins: -1,
     winrate: -1,
     relationship: 2,
@@ -26,10 +26,10 @@ const deadValue: RelationshipSummary = {
 
 export function getRelationshipSummary(hero: Houseguest, villain: Houseguest): RelationshipSummary {
     const doIWin = hero.superiors[villain.id];
-    const type = classifyRelationship(hero.popularity, villain.popularity, hero.relationshipWith(villain));
+    const type = classifyRelationship(hero.popularity, villain.popularity, hero.relationships[villain.id]);
     return {
         id: villain.id,
-        relationship: villain.relationshipWith(hero),
+        relationship: villain.relationships[hero.id],
         type,
         winrate: hero.powerRanking,
         pHeroWins: doIWin,
@@ -88,13 +88,14 @@ function determineStrategy(hero: Houseguest): TargetStrategy {
     return hero.friends > hero.enemies ? TargetStrategy.StatusQuo : TargetStrategy.Underdog;
 }
 
-// TODO: i forgot to take into account jury.
 export function isBetterTargetWithLogic(
     old: RelationshipSummary,
     neww: RelationshipSummary,
     hero: Houseguest,
     gameState: GameState
 ): NumberWithLogic {
+    if (old.relationship === 2) return { decision: 1, reason: "remove debug value" };
+    if (neww.relationship === 2) return { decision: 0, reason: "remove debug value" };
     const strategy = determineStrategy(hero);
     const winrateStrategy = determineWinrateStrategy(hero);
     if (strategy === TargetStrategy.StatusQuo)
@@ -112,7 +113,6 @@ export function isBetterTarget(
     hero: Houseguest,
     gameState: GameState
 ): boolean {
-    if (old.relationship === 2) return true;
     return isBetterTargetWithLogic(old, neww, hero, gameState).decision === 1;
 }
 
@@ -156,7 +156,7 @@ function isBetterTargetMoR(
     )
         ? 1
         : 0;
-    return { decision, reason: `${[old, neww][decision].villianName} is a bigger threat.` };
+    return { decision, reason: `${[old, neww][decision].villianName} is a bigger threat to me.` };
 }
 
 function isBetterTargetUnderdog(
@@ -190,7 +190,7 @@ function isBetterTargetUnderdog(
     )
         ? 1
         : 0;
-    return { decision, reason: `${[old, neww][decision].villianName} is a bigger threat.` };
+    return { decision, reason: `${[old, neww][decision].villianName} is a bigger threat to me.` };
 }
 
 // returns true if neww is more central than old

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -126,7 +126,7 @@ function voteBasedOnCentrality(
         const decision = isMoreCentral(hero, nominees[0], nominees[1], gameState, internalCallback) ? 1 : 0;
         return {
             decision,
-            reason: `${[nominees[0], nominees[1]][decision].villianName} is a bigger threat to me.`,
+            reason: `${[nominees[0], nominees[1]][decision].villianName} is more popular among my enemies.`,
         };
     };
 }


### PR DESCRIPTION
New Twists:

- No Veto Week: A week with no veto, in the style of Big Brother 2 (US).
- Diamond Veto: A week where the veto winner can name the replacement nominee.
- Forced Veto: A week where whoever wins the veto is forced to use it.

Updated Casts:

- Brazillian Soccer Mascots (updated by @domasan12#2527)
- Monica and Friends (updated by @domasan12#2527)
- Scandanavia and the World (updated by @domasan12#2527)
- The Genius S1-4 renamed to The Genius 1-4
- rps101 renamed to Rock Paper Scissors 101

New Casts:

- Eternal Return
- LOONA (contributed by @jtf.#8402)
- Countries (contributed by @domasan12#2527)
- United States of America (contributed by @domasan12#2527)
- Brazilian States (contributed by @domasan12#2527)
- Pinoy Big Brother Celebrity Edition 1 (contributed by @KeitaroMorikawa#4189)
- Pinoy Big Brother Teen Edition 1 (contributed by @KeitaroMorikawa#4189)
- Valo Vilag 9 (contributed by @Albino#3077)
- Valo Vilag 6 (contributed by @Albino#3077)

Other Features:

- You can now sort the casts from A to Z on the casting screen.
- The logic has been slightly reworked. You may now notice people giving new reasoning while voting. 

Bugfixes:

- Fixed a bug where the game could sometimes crash if the final 4 vote was pre-jury.
