### PR TITLE
Veto update part 2

### DIFF
--- a/src/components/castingScreen/numericInput.tsx
+++ b/src/components/castingScreen/numericInput.tsx
@@ -11,7 +11,6 @@ interface NumericInputProps {
 
 export const NumericInputStyle = styled.input`
     width: 3em;
-    marginleft: 5px;
 `;
 
 export function NumericInput(props: NumericInputProps) {

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -90,21 +90,32 @@ export function generateBBVanillaScenes(
     scenes: Scene[];
     title: string;
 } {
-    let hoh: Houseguest;
+    let hohArray: Houseguest[];
     let currentGameState: GameState;
     let hohCompScene: Scene;
     const scenes: Scene[] = [];
 
-    [currentGameState, hohCompScene, hoh] = generateHohCompScene(initialGamestate, { doubleEviction });
+    [currentGameState, hohCompScene, hohArray] = generateHohCompScene(initialGamestate, { doubleEviction });
+    const hoh = hohArray[0];
     scenes.push(hohCompScene);
 
     let nomCeremonyScene;
     let nominees: Houseguest[];
-    [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, hoh, {
+    [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, [hoh], {
         doubleEviction,
     });
     scenes.push(nomCeremonyScene);
 
+    return generateVetoScenesOnwards(veto, currentGameState, hoh, nominees, doubleEviction, scenes);
+}
+export function generateVetoScenesOnwards(
+    veto: Veto | null,
+    currentGameState: GameState,
+    hoh: Houseguest,
+    nominees: Houseguest[],
+    doubleEviction: boolean,
+    scenes: Scene[]
+) {
     if (veto) {
         let vetoCompScene;
         let povWinner: Houseguest;

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -22,6 +22,7 @@ export const BigBrotherVanilla: EpisodeType = {
     hasViewsbar: true,
     name: "BigBrotherVanilla",
     emoji: "",
+    description: "",
     generate: generateBbVanilla,
 };
 

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -74,7 +74,6 @@ export function defaultContent(initialGameState: GameState) {
 export function generateBbVanilla(initialGamestate: GameState): Episode {
     const episode = generateBBVanillaScenes(initialGamestate, GoldenVeto);
     return new Episode({
-        title: episode.title,
         scenes: episode.scenes,
         gameState: new GameState(episode.gameState),
         initialGamestate,
@@ -89,7 +88,6 @@ export function generateBBVanillaScenes(
 ): {
     gameState: GameState;
     scenes: Scene[];
-    title: string;
 } {
     let hohArray: Houseguest[];
     let currentGameState: GameState;
@@ -150,6 +148,5 @@ export function generateVetoScenesOnwards(
         currentGameState.currentLog.nominationsPostVeto = currentGameState.currentLog.nominationsPreVeto;
     }
     scenes.push(evictionScene);
-    const title = `Week ${currentGameState.phase}`;
-    return { gameState: currentGameState, scenes, title };
+    return { gameState: currentGameState, scenes };
 }

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -116,9 +116,9 @@ export function generateVetoScenesOnwards(
     doubleEviction: boolean,
     scenes: Scene[]
 ) {
+    let povWinner: Houseguest | undefined = undefined;
     if (veto) {
         let vetoCompScene;
-        let povWinner: Houseguest;
         [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
             currentGameState,
             [hoh],
@@ -140,8 +140,9 @@ export function generateVetoScenesOnwards(
         scenes.push(vetoCeremonyScene);
     }
     let evictionScene;
-    [currentGameState, evictionScene] = generateEvictionScene(currentGameState, hoh, nominees, {
+    [currentGameState, evictionScene] = generateEvictionScene(currentGameState, [hoh], nominees, {
         doubleEviction,
+        povWinner,
         votingTo: "Evict",
     });
     if (veto === null) {

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -121,7 +121,7 @@ export function generateVetoScenesOnwards(
         let povWinner: Houseguest;
         [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
             currentGameState,
-            hoh,
+            [hoh],
             nominees,
             veto,
             doubleEviction
@@ -131,7 +131,7 @@ export function generateVetoScenesOnwards(
 
         [currentGameState, vetoCeremonyScene, nominees] = generateVetoCeremonyScene(
             currentGameState,
-            hoh,
+            [hoh],
             nominees,
             povWinner,
             doubleEviction,

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -21,6 +21,7 @@ export const BigBrotherVanilla: EpisodeType = {
     arrowsEnabled: true,
     hasViewsbar: true,
     name: "BigBrotherVanilla",
+    emoji: "",
     generate: generateBbVanilla,
 };
 

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -105,7 +105,7 @@ export function generateBBVanillaScenes(
     });
     scenes.push(nomCeremonyScene);
 
-    return generateVetoScenesOnwards(veto, currentGameState, hoh, nominees, doubleEviction, scenes);
+    return generateVetoScenesOnwards(veto, currentGameState, hoh, nominees, doubleEviction, scenes, []);
 }
 export function generateVetoScenesOnwards(
     veto: Veto | null,
@@ -113,7 +113,8 @@ export function generateVetoScenesOnwards(
     hoh: Houseguest,
     nominees: Houseguest[],
     doubleEviction: boolean,
-    scenes: Scene[]
+    scenes: Scene[],
+    immuneHgs: Houseguest[]
 ) {
     let povWinner: Houseguest | undefined = undefined;
     if (veto) {
@@ -134,7 +135,8 @@ export function generateVetoScenesOnwards(
             nominees,
             povWinner,
             doubleEviction,
-            veto
+            veto,
+            immuneHgs
         );
         scenes.push(vetoCeremonyScene);
     }

--- a/src/components/episode/bigBrotherFinale.tsx
+++ b/src/components/episode/bigBrotherFinale.tsx
@@ -13,6 +13,7 @@ export const BigBrotherFinale: EpisodeType = {
     canPlayWith: (n: number) => n === 3,
     eliminates: 2,
     arrowsEnabled: true,
+    emoji: "",
     hasViewsbar: true,
     name: "Big Brother Finale",
     generate: generateBbFinale,

--- a/src/components/episode/bigBrotherFinale.tsx
+++ b/src/components/episode/bigBrotherFinale.tsx
@@ -16,6 +16,7 @@ export const BigBrotherFinale: EpisodeType = {
     emoji: "",
     hasViewsbar: true,
     name: "Big Brother Finale",
+    description: "",
     generate: generateBbFinale,
 };
 

--- a/src/components/episode/boomerangVetoEpisode.tsx
+++ b/src/components/episode/boomerangVetoEpisode.tsx
@@ -9,6 +9,7 @@ export const BoomerangVetoEpisode: EpisodeType = {
     arrowsEnabled: true,
     hasViewsbar: true,
     emoji: "🪃",
+    description: "A veto that must be discarded or used to save both nominees.",
     name: "Boomerang Veto",
     generate: generate,
 };

--- a/src/components/episode/boomerangVetoEpisode.tsx
+++ b/src/components/episode/boomerangVetoEpisode.tsx
@@ -1,0 +1,24 @@
+import { GameState } from "../../model";
+import { generateBBVanillaScenes } from "./bigBrotherEpisode";
+import { EpisodeType, Episode } from "./episodes";
+import { BoomerangVeto } from "./veto/veto";
+
+export const BoomerangVetoEpisode: EpisodeType = {
+    canPlayWith: (n: number) => n >= 5,
+    eliminates: 1,
+    arrowsEnabled: true,
+    hasViewsbar: true,
+    name: "🪃 Boomerang Veto",
+    generate: generate,
+};
+
+function generate(initialGamestate: GameState): Episode {
+    const episode = generateBBVanillaScenes(initialGamestate, BoomerangVeto);
+    return new Episode({
+        gameState: new GameState(episode.gameState),
+        initialGamestate,
+        title: episode.title,
+        scenes: episode.scenes,
+        type: BoomerangVetoEpisode,
+    });
+}

--- a/src/components/episode/boomerangVetoEpisode.tsx
+++ b/src/components/episode/boomerangVetoEpisode.tsx
@@ -8,7 +8,8 @@ export const BoomerangVetoEpisode: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "🪃 Boomerang Veto",
+    emoji: "🪃",
+    name: "Boomerang Veto",
     generate: generate,
 };
 

--- a/src/components/episode/boomerangVetoEpisode.tsx
+++ b/src/components/episode/boomerangVetoEpisode.tsx
@@ -18,7 +18,6 @@ function generate(initialGamestate: GameState): Episode {
     return new Episode({
         gameState: new GameState(episode.gameState),
         initialGamestate,
-        title: episode.title,
         scenes: episode.scenes,
         type: BoomerangVetoEpisode,
     });

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -1,0 +1,47 @@
+import { GameState, Houseguest, MutableGameState } from "../../model";
+import { Episode, EpisodeType } from "./episodes";
+import { Scene } from "./scenes/scene";
+import { generateHohCompScene } from "./scenes/hohCompScene";
+import { generateBotbNomCeremonyScene } from "./scenes/botbNomCeremonyScene";
+
+export const BattleOfTheBlock: EpisodeType = {
+    canPlayWith: (n: number) => n >= 6,
+    eliminates: 1,
+    arrowsEnabled: true,
+    hasViewsbar: true,
+    name: "⚔️ Battle of the Block",
+    generate: generateBoB,
+};
+
+function generateBoB(initialGamestate: GameState): Episode {
+    // generate (co)-hoh scene
+    let currentGameState = new MutableGameState(initialGamestate);
+    let hohArray: Houseguest[];
+    let hohCompScene: Scene;
+    const scenes: Scene[] = [];
+    [currentGameState, hohCompScene, hohArray] = generateHohCompScene(currentGameState, {
+        coHoH: true,
+        coHohIsFinal: false,
+    });
+    scenes.push(hohCompScene);
+    // nominations, but with TWO sets of nominees
+    let nomCeremonyScene;
+    let nominees: Houseguest[][];
+    [currentGameState, nomCeremonyScene, nominees] = generateBotbNomCeremonyScene(
+        currentGameState,
+        hohArray[0],
+        hohArray[1]
+    );
+    scenes.push(nomCeremonyScene);
+    // then battle of the block where one of the HoHs is dethroned
+
+    // then veto onwards plays normally
+
+    return new Episode({
+        gameState: new GameState(currentGameState),
+        initialGamestate,
+        title: `Week ${currentGameState.phase}`,
+        scenes,
+        type: BattleOfTheBlock,
+    });
+}

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -8,8 +8,9 @@ export const BattleOfTheBlock: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
     eliminates: 1,
     arrowsEnabled: true,
+    emoji: "⚔️",
     hasViewsbar: true,
-    name: "⚔️ Battle of the Block",
+    name: "Battle of the Block",
     generate: generateBoB,
 };
 

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -41,21 +41,23 @@ function generateBoB(initialGamestate: GameState): Episode {
     let botbscene;
     let finalhoh;
     let finalnoms;
-    [currentGameState, botbscene, finalhoh, finalnoms] = generateBotbScene(currentGameState, hohArray, [
-        ...nominees[0],
-        ...nominees[1],
-    ]);
+    let botbWinners;
+    [currentGameState, botbscene, finalhoh, finalnoms, botbWinners] = generateBotbScene(
+        currentGameState,
+        hohArray,
+        [...nominees[0], ...nominees[1]]
+    );
     scenes.push(botbscene);
     // then veto onwards plays normally except
-    // TODO: the winning pair is somehow immune for the week: they can't be backdoored.
-
+    // the winning pair is somehow immune for the week: they can't be backdoored.
     const vetostuff = generateVetoScenesOnwards(
         GoldenVeto,
         currentGameState,
         finalhoh,
         finalnoms,
         false,
-        scenes
+        scenes,
+        botbWinners
     );
     currentGameState = vetostuff.gameState;
 

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -41,7 +41,6 @@ function generateBoB(initialGamestate: GameState): Episode {
     return new Episode({
         gameState: new GameState(currentGameState),
         initialGamestate,
-        title: `Week ${currentGameState.phase}`,
         scenes,
         type: BattleOfTheBlock,
     });

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -3,6 +3,9 @@ import { Episode, EpisodeType } from "./episodes";
 import { Scene } from "./scenes/scene";
 import { generateHohCompScene } from "./scenes/hohCompScene";
 import { generateBotbNomCeremonyScene } from "./scenes/botbNomCeremonyScene";
+import { generateVetoScenesOnwards } from "./bigBrotherEpisode";
+import { GoldenVeto } from "./veto/veto";
+import { generateBotbScene } from "./scenes/botbScene";
 
 export const BattleOfTheBlock: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
@@ -35,13 +38,31 @@ function generateBoB(initialGamestate: GameState): Episode {
     );
     scenes.push(nomCeremonyScene);
     // then battle of the block where one of the HoHs is dethroned
+    let botbscene;
+    let finalhoh;
+    let finalnoms;
+    [currentGameState, botbscene, finalhoh, finalnoms] = generateBotbScene(currentGameState, hohArray, [
+        ...nominees[0],
+        ...nominees[1],
+    ]);
+    scenes.push(botbscene);
+    // then veto onwards plays normally except
+    // TODO: the winning pair is somehow immune for the week: they can't be backdoored.
 
-    // then veto onwards plays normally
+    const vetostuff = generateVetoScenesOnwards(
+        GoldenVeto,
+        currentGameState,
+        finalhoh,
+        finalnoms,
+        false,
+        scenes
+    );
+    currentGameState = vetostuff.gameState;
 
     return new Episode({
         gameState: new GameState(currentGameState),
         initialGamestate,
-        scenes,
+        scenes: vetostuff.scenes,
         type: BattleOfTheBlock,
     });
 }

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -14,6 +14,8 @@ export const BattleOfTheBlock: EpisodeType = {
     emoji: "⚔️",
     hasViewsbar: true,
     name: "Battle of the Block",
+    description:
+        "Two HoHs name a total of four nominees. The nominees compete in a competition, and the winners are safe for the week and dethrone the HoH who nominated them.",
     generate: generateBoB,
 };
 

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -8,6 +8,7 @@ import { generateHohCompScene } from "./scenes/hohCompScene";
 import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
 import { generateVetoCompScene } from "./scenes/vetoCompScene";
 import { generateVetoCeremonyScene } from "./scenes/vetoCeremonyScene";
+import { generateEvictionScene } from "./scenes/evictionScene";
 
 export const CoHoH: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
@@ -59,7 +60,12 @@ function generateCoHoH(initialGamestate: GameState): Episode {
     scenes.push(vetoCeremonyScene);
 
     // then eviction scene
-
+    let evictionScene;
+    [currentGameState, evictionScene] = generateEvictionScene(currentGameState, hohArray, nominees, {
+        votingTo: "Evict",
+        povWinner,
+    });
+    scenes.push(evictionScene);
     // currentGameState = doubleEviction.gameState;
     return new Episode({
         gameState: new GameState(currentGameState),

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -68,7 +68,6 @@ function generateCoHoH(initialGamestate: GameState): Episode {
     return new Episode({
         gameState: new GameState(currentGameState),
         initialGamestate,
-        title: `Week ${currentGameState.phase}`,
         scenes,
         type: CoHoH,
     });

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -14,6 +14,8 @@ export const CoHoH: EpisodeType = {
     arrowsEnabled: true,
     hasViewsbar: true,
     name: "Co-HoH",
+    description:
+        "Two HoHs each name one nominee, and are responsible for replacing the person they nominated if the veto is used on them.",
     emoji: "👥",
     generate: generateCoHoH,
 };

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -13,7 +13,8 @@ export const CoHoH: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: true,
     hasViewsbar: true,
-    name: "👥 Co-HoH",
+    name: "Co-HoH",
+    emoji: "👥",
     generate: generateCoHoH,
 };
 

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -54,7 +54,8 @@ function generateCoHoH(initialGamestate: GameState): Episode {
         nominees,
         povWinner,
         false,
-        GoldenVeto
+        GoldenVeto,
+        []
     );
     scenes.push(vetoCeremonyScene);
 

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -6,6 +6,7 @@ import { Scene } from "./scenes/scene";
 import { GoldenVeto } from "./veto/veto";
 import { generateHohCompScene } from "./scenes/hohCompScene";
 import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
+import { generateVetoCompScene } from "./scenes/vetoCompScene";
 
 export const CoHoH: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
@@ -33,7 +34,19 @@ function generateCoHoH(initialGamestate: GameState): Episode {
     let nominees: Houseguest[];
     [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, hohArray, {});
     scenes.push(nomCeremonyScene);
+    // veto comp
+    let vetoCompScene;
+    let povWinner: Houseguest;
+    [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
+        currentGameState,
+        hohArray[0],
+        [hohArray[1], ...nominees],
+        GoldenVeto,
+        true
+    );
+    scenes.push(vetoCompScene);
     // veto replacement scene might be different because each hoh nominated one person, so whoever gets vetoed, that hoh replaces
+
     // veto scene is normal, but eviction scene the veto winner breaks the tie
     //
     //

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -1,0 +1,50 @@
+import { GameState, Houseguest, MutableGameState } from "../../model";
+import { generateBBVanillaScenes } from "./bigBrotherEpisode";
+import { Episode, EpisodeType } from "./episodes";
+import React from "react";
+import { Scene } from "./scenes/scene";
+import { GoldenVeto } from "./veto/veto";
+import { generateHohCompScene } from "./scenes/hohCompScene";
+
+export const CoHoH: EpisodeType = {
+    canPlayWith: (n: number) => n >= 5,
+    eliminates: 1,
+    arrowsEnabled: true,
+    hasViewsbar: true,
+    name: "👥 Co-HoH",
+    generate: generateCoHoH,
+};
+
+function generateCoHoH(initialGamestate: GameState): Episode {
+    // generate (co)-hoh scene
+    let currentGameState = new MutableGameState(initialGamestate);
+    let hohArray: Houseguest[];
+    let hohCompScene: Scene;
+    const scenes: Scene[] = [];
+    [currentGameState, hohCompScene, hohArray] = generateHohCompScene(currentGameState, {
+        coHoH: true,
+        coHohIsFinal: true,
+    });
+    scenes.push(hohCompScene);
+
+    // generate nominations scene
+
+    // veto replacement scene might be different because each hoh nominated one person, so whoever gets vetoed, that hoh replaces
+    // veto scene is normal, but eviction scene the veto winner breaks the tie
+    //
+    //
+    //
+    // const episode = generateBBVanillaScenes(initialGamestate, GoldenVeto);
+    // let currentGameState = episode.gameState;
+    // const scenes: Scene[] = episode.scenes;
+    // currentGameState.incrementLogIndex();
+    // const doubleEviction = generateBBVanillaScenes(currentGameState, GoldenVeto, true);
+    // currentGameState = doubleEviction.gameState;
+    return new Episode({
+        gameState: new GameState(currentGameState),
+        initialGamestate,
+        title: `Week ${currentGameState.phase}`,
+        scenes,
+        type: CoHoH,
+    });
+}

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { Scene } from "./scenes/scene";
 import { GoldenVeto } from "./veto/veto";
 import { generateHohCompScene } from "./scenes/hohCompScene";
+import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
 
 export const CoHoH: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
@@ -28,7 +29,10 @@ function generateCoHoH(initialGamestate: GameState): Episode {
     scenes.push(hohCompScene);
 
     // generate nominations scene
-
+    let nomCeremonyScene;
+    let nominees: Houseguest[];
+    [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, hohArray, {});
+    scenes.push(nomCeremonyScene);
     // veto replacement scene might be different because each hoh nominated one person, so whoever gets vetoed, that hoh replaces
     // veto scene is normal, but eviction scene the veto winner breaks the tie
     //

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -1,7 +1,5 @@
 import { GameState, Houseguest, MutableGameState } from "../../model";
-import { generateBBVanillaScenes } from "./bigBrotherEpisode";
 import { Episode, EpisodeType } from "./episodes";
-import React from "react";
 import { Scene } from "./scenes/scene";
 import { GoldenVeto } from "./veto/veto";
 import { generateHohCompScene } from "./scenes/hohCompScene";
@@ -66,7 +64,6 @@ function generateCoHoH(initialGamestate: GameState): Episode {
         povWinner,
     });
     scenes.push(evictionScene);
-    // currentGameState = doubleEviction.gameState;
     return new Episode({
         gameState: new GameState(currentGameState),
         initialGamestate,

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -7,6 +7,7 @@ import { GoldenVeto } from "./veto/veto";
 import { generateHohCompScene } from "./scenes/hohCompScene";
 import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
 import { generateVetoCompScene } from "./scenes/vetoCompScene";
+import { generateVetoCeremonyScene } from "./scenes/vetoCeremonyScene";
 
 export const CoHoH: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
@@ -39,23 +40,26 @@ function generateCoHoH(initialGamestate: GameState): Episode {
     let povWinner: Houseguest;
     [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
         currentGameState,
-        hohArray[0],
-        [hohArray[1], ...nominees],
-        GoldenVeto,
-        true
+        hohArray,
+        nominees,
+        GoldenVeto
     );
     scenes.push(vetoCompScene);
     // veto replacement scene might be different because each hoh nominated one person, so whoever gets vetoed, that hoh replaces
+    let vetoCeremonyScene;
 
-    // veto scene is normal, but eviction scene the veto winner breaks the tie
-    //
-    //
-    //
-    // const episode = generateBBVanillaScenes(initialGamestate, GoldenVeto);
-    // let currentGameState = episode.gameState;
-    // const scenes: Scene[] = episode.scenes;
-    // currentGameState.incrementLogIndex();
-    // const doubleEviction = generateBBVanillaScenes(currentGameState, GoldenVeto, true);
+    [currentGameState, vetoCeremonyScene, nominees] = generateVetoCeremonyScene(
+        currentGameState,
+        hohArray,
+        nominees,
+        povWinner,
+        false,
+        GoldenVeto
+    );
+    scenes.push(vetoCeremonyScene);
+
+    // then eviction scene
+
     // currentGameState = doubleEviction.gameState;
     return new Episode({
         gameState: new GameState(currentGameState),

--- a/src/components/episode/diamondVetoEpisode.tsx
+++ b/src/components/episode/diamondVetoEpisode.tsx
@@ -18,7 +18,6 @@ function generateNoVeto(initialGamestate: GameState): Episode {
     return new Episode({
         gameState: new GameState(episode.gameState),
         initialGamestate,
-        title: episode.title,
         scenes: episode.scenes,
         type: DiamondVetoEpisode,
     });

--- a/src/components/episode/diamondVetoEpisode.tsx
+++ b/src/components/episode/diamondVetoEpisode.tsx
@@ -7,8 +7,9 @@ export const DiamondVetoEpisode: EpisodeType = {
     canPlayWith: (n: number) => n >= 4,
     eliminates: 1,
     arrowsEnabled: true,
+    emoji: "💎",
     hasViewsbar: true,
-    name: "💎 Diamond Veto",
+    name: "Diamond Veto",
     generate: generateNoVeto,
 };
 

--- a/src/components/episode/diamondVetoEpisode.tsx
+++ b/src/components/episode/diamondVetoEpisode.tsx
@@ -10,6 +10,7 @@ export const DiamondVetoEpisode: EpisodeType = {
     emoji: "💎",
     hasViewsbar: true,
     name: "Diamond Veto",
+    description: "The veto winner has the right to name a replacement nominee.",
     generate: generateNoVeto,
 };
 

--- a/src/components/episode/doubleEvictionEpisode.tsx
+++ b/src/components/episode/doubleEvictionEpisode.tsx
@@ -12,6 +12,7 @@ export const DoubleEviction: EpisodeType = {
     emoji: "⏩",
     hasViewsbar: true,
     name: "Double Eviction",
+    description: "A second round of Big Brother plays out in a single scene.",
     generate: generateDoubleEviction,
 };
 

--- a/src/components/episode/doubleEvictionEpisode.tsx
+++ b/src/components/episode/doubleEvictionEpisode.tsx
@@ -34,7 +34,6 @@ function generateDoubleEviction(initialGamestate: GameState): Episode {
     return new Episode({
         gameState: new GameState(currentGameState),
         initialGamestate,
-        title: episode.title,
         scenes,
         type: DoubleEviction,
     });

--- a/src/components/episode/doubleEvictionEpisode.tsx
+++ b/src/components/episode/doubleEvictionEpisode.tsx
@@ -9,8 +9,9 @@ export const DoubleEviction: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
     eliminates: 2,
     arrowsEnabled: true,
+    emoji: "⏩",
     hasViewsbar: true,
-    name: "⏩ Double Eviction",
+    name: "Double Eviction",
     generate: generateDoubleEviction,
 };
 

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -6,7 +6,7 @@ import { defaultContent } from "./bigBrotherEpisode";
 
 export interface InitEpisode {
     scenes: Scene[];
-    title: string;
+    title?: string;
     content?: JSX.Element;
     gameState: GameState;
     initialGamestate?: GameState;
@@ -32,7 +32,7 @@ export class Episode {
 
     constructor(init: InitEpisode) {
         this.scenes = init.scenes;
-        this.title = init.title;
+        this.title = init.title || `Week ${init.gameState.phase}`;
         this.content = init.content || defaultContent(init.initialGamestate || init.gameState);
         this.gameState = init.gameState;
         this.initialGameState = init.initialGamestate || init.gameState;

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -48,5 +48,6 @@ export interface EpisodeType {
     readonly hasViewsbar: boolean;
     readonly name: string;
     readonly emoji: string;
+    readonly description: string;
     readonly generate: (gameState: GameState) => Episode;
 }

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -3,6 +3,7 @@ import { GameState } from "../../model/gameState";
 import { Scene } from "./scenes/scene";
 import { ViewsBar } from "../viewsBar/viewBar";
 import { defaultContent } from "./bigBrotherEpisode";
+import { getEmoji } from "../seasonEditor/twistAdder";
 
 export interface InitEpisode {
     scenes: Scene[];
@@ -32,7 +33,7 @@ export class Episode {
 
     constructor(init: InitEpisode) {
         this.scenes = init.scenes;
-        this.title = init.title || `Week ${init.gameState.phase}`;
+        this.title = init.title || `Week ${init.gameState.phase} ${getEmoji(init.type)}`;
         this.content = init.content || defaultContent(init.initialGamestate || init.gameState);
         this.gameState = init.gameState;
         this.initialGameState = init.initialGamestate || init.gameState;

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -20,7 +20,6 @@ export class Episode {
     readonly gameState: GameState;
     readonly initialGameState: GameState;
     readonly type: EpisodeType;
-    readonly arrowsEnabled: boolean = true;
     get render(): JSX.Element {
         const viewsBar = this.type.hasViewsbar ? <ViewsBar gameState={this.scenes[0].gameState} /> : null;
         return (
@@ -47,5 +46,6 @@ export interface EpisodeType {
     readonly arrowsEnabled: boolean;
     readonly hasViewsbar: boolean;
     readonly name: string;
+    readonly emoji: string;
     readonly generate: (gameState: GameState) => Episode;
 }

--- a/src/components/episode/forcedVetoEpisode.tsx
+++ b/src/components/episode/forcedVetoEpisode.tsx
@@ -7,8 +7,9 @@ export const ForcedVetoEpisode: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
     eliminates: 1,
     arrowsEnabled: true,
+    emoji: "🔦",
     hasViewsbar: true,
-    name: "🔦 Forced Veto",
+    name: "Forced Veto",
     generate: generateForcedVeto,
 };
 

--- a/src/components/episode/forcedVetoEpisode.tsx
+++ b/src/components/episode/forcedVetoEpisode.tsx
@@ -18,7 +18,6 @@ function generateForcedVeto(initialGamestate: GameState): Episode {
     return new Episode({
         gameState: new GameState(episode.gameState),
         initialGamestate,
-        title: episode.title,
         scenes: episode.scenes,
         type: ForcedVetoEpisode,
     });

--- a/src/components/episode/forcedVetoEpisode.tsx
+++ b/src/components/episode/forcedVetoEpisode.tsx
@@ -10,6 +10,7 @@ export const ForcedVetoEpisode: EpisodeType = {
     emoji: "🔦",
     hasViewsbar: true,
     name: "Forced Veto",
+    description: "The veto winner must use the veto.",
     generate: generateForcedVeto,
 };
 

--- a/src/components/episode/forcedVetoEpisode.tsx
+++ b/src/components/episode/forcedVetoEpisode.tsx
@@ -4,7 +4,7 @@ import { EpisodeType, Episode } from "./episodes";
 import { SpotlightVeto } from "./veto/veto";
 
 export const ForcedVetoEpisode: EpisodeType = {
-    canPlayWith: (n: number) => n >= 4,
+    canPlayWith: (n: number) => n >= 5,
     eliminates: 1,
     arrowsEnabled: true,
     hasViewsbar: true,

--- a/src/components/episode/gameOver.tsx
+++ b/src/components/episode/gameOver.tsx
@@ -9,6 +9,7 @@ export const GameOver: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: false,
     hasViewsbar: false,
+    emoji: "",
     name: "Game Over",
     generate: generateGameOver,
 };

--- a/src/components/episode/gameOver.tsx
+++ b/src/components/episode/gameOver.tsx
@@ -9,6 +9,7 @@ export const GameOver: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: false,
     hasViewsbar: false,
+    description: "",
     emoji: "",
     name: "Game Over",
     generate: generateGameOver,

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -12,6 +12,7 @@ export const InstantEviction: EpisodeType = {
     emoji: "⚡",
     hasViewsbar: true,
     name: "Instant Eviction",
+    description: "A double eviction without a veto.",
     generate: generateInstantEviction,
 };
 

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -9,8 +9,9 @@ export const InstantEviction: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
     eliminates: 2,
     arrowsEnabled: true,
+    emoji: "⚡",
     hasViewsbar: true,
-    name: "⚡ Instant Eviction",
+    name: "Instant Eviction",
     generate: generateInstantEviction,
 };
 

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -35,7 +35,6 @@ function generateInstantEviction(initialGamestate: GameState): Episode {
     return new Episode({
         gameState: new GameState(currentGameState),
         initialGamestate,
-        title: episode.title,
         scenes,
         type: InstantEviction,
     });

--- a/src/components/episode/noVetoEpisode.tsx
+++ b/src/components/episode/noVetoEpisode.tsx
@@ -9,6 +9,7 @@ export const NoVeto: EpisodeType = {
     emoji: "🚫",
     hasViewsbar: true,
     name: "No Veto",
+    description: "A week without a veto.",
     generate: generateNoVeto,
 };
 

--- a/src/components/episode/noVetoEpisode.tsx
+++ b/src/components/episode/noVetoEpisode.tsx
@@ -17,7 +17,6 @@ function generateNoVeto(initialGamestate: GameState): Episode {
     return new Episode({
         gameState: new GameState(episode.gameState),
         initialGamestate,
-        title: episode.title,
         scenes: episode.scenes,
         type: NoVeto,
     });

--- a/src/components/episode/noVetoEpisode.tsx
+++ b/src/components/episode/noVetoEpisode.tsx
@@ -6,8 +6,9 @@ export const NoVeto: EpisodeType = {
     canPlayWith: (n: number) => n >= 4,
     eliminates: 1,
     arrowsEnabled: true,
+    emoji: "🚫",
     hasViewsbar: true,
-    name: "🚫 No Veto",
+    name: "No Veto",
     generate: generateNoVeto,
 };
 

--- a/src/components/episode/pregameEpisode.tsx
+++ b/src/components/episode/pregameEpisode.tsx
@@ -12,6 +12,7 @@ const PregameEpisodeType: EpisodeType = {
     emoji: "",
     hasViewsbar: false,
     name: "Pregame",
+    description: "",
     generate: (gameState: GameState) => new PregameEpisode(gameState),
 };
 

--- a/src/components/episode/pregameEpisode.tsx
+++ b/src/components/episode/pregameEpisode.tsx
@@ -9,6 +9,7 @@ const PregameEpisodeType: EpisodeType = {
         return n > 2;
     },
     arrowsEnabled: true,
+    emoji: "",
     hasViewsbar: false,
     name: "Pregame",
     generate: (gameState: GameState) => new PregameEpisode(gameState),

--- a/src/components/episode/safetyChain.tsx
+++ b/src/components/episode/safetyChain.tsx
@@ -3,21 +3,21 @@ import { Episode, EpisodeType } from "./episodes";
 import { Scene } from "./scenes/scene";
 import { generateSafetyChainScene } from "./scenes/safetyChainScene";
 
-export const SafetyChain: EpisodeType = {
-    canPlayWith: (n: number) => n >= 3,
-    eliminates: 1,
-    arrowsEnabled: true,
-    hasViewsbar: true,
-    name: "Safety Chain",
-    generate: generateSafetyChain,
-};
+// export const SafetyChain: EpisodeType = {
+//     canPlayWith: (n: number) => n >= 3,
+//     eliminates: 1,
+//     arrowsEnabled: true,
+//     hasViewsbar: true,
+//     name: "Safety Chain",
+//     generate: generateSafetyChain,
+// };
 
-export function generateSafetyChain(initialGameState: GameState): Episode {
-    let currentGameState: GameState = initialGameState;
-    const title = `Safety Chain ${currentGameState.phase}`;
-    const scenes: Scene[] = [];
-    let safetyChainScene;
-    [currentGameState, safetyChainScene] = generateSafetyChainScene(initialGameState);
-    scenes.push(safetyChainScene);
-    return new Episode({ gameState: currentGameState, title, scenes, type: SafetyChain });
+export function generateSafetyChain(initialGameState: GameState): void {
+    // let currentGameState: GameState = initialGameState;
+    // const title = `Safety Chain ${currentGameState.phase}`;
+    // const scenes: Scene[] = [];
+    // let safetyChainScene;
+    // [currentGameState, safetyChainScene] = generateSafetyChainScene(initialGameState);
+    // scenes.push(safetyChainScene);
+    // return new Episode({ gameState: currentGameState, title, scenes, type: SafetyChain });
 }

--- a/src/components/episode/scenes/botbNomCeremonyScene.tsx
+++ b/src/components/episode/scenes/botbNomCeremonyScene.tsx
@@ -46,7 +46,14 @@ export function generateBotbNomCeremonyScene(
                     This is the nomination ceremony. It is our responsibility as Heads of Household to each
                     nominate two houseguests for eviction.
                 </Centered>
-                <Portraits centered={true} houseguests={[hoh1]} />
+                <div className="columns is-marginless is-centered is-mobile">
+                    <div className="column">
+                        <Portrait centered={true} houseguest={hoh1} />
+                    </div>
+                    <div className="column">
+                        <Portrait centered={true} houseguest={hoh2} />
+                    </div>
+                </div>
                 <div className="columns is-marginless is-centered">
                     <DividerBox className="column">
                         <Centered>{firstText}</Centered>
@@ -56,11 +63,6 @@ export function generateBotbNomCeremonyScene(
                         <Centered>{secondText}</Centered>
                         <Portrait centered={true} houseguest={noms1[1]} />
                     </DividerBox>
-                </div>
-                <CenteredBold>{finalStatement(noms1)}</CenteredBold>
-                <div style={{ marginTop: 50 }} />
-                <Portraits centered={true} houseguests={[hoh2]} />
-                <div className="columns is-marginless is-centered">
                     <DividerBox className="column">
                         <Centered>{firstText}</Centered>
                         <Portrait centered={true} houseguest={noms2[0]} />
@@ -70,7 +72,14 @@ export function generateBotbNomCeremonyScene(
                         <Portrait centered={true} houseguest={noms2[1]} />
                     </DividerBox>
                 </div>
-                <CenteredBold>{finalStatement(noms2)}</CenteredBold>
+                <div className="columns is-marginless is-centered is-mobile">
+                    <div className="column">
+                        <CenteredBold>{finalStatement(noms1)}</CenteredBold>
+                    </div>
+                    <div className="column">
+                        <CenteredBold>{finalStatement(noms2)}</CenteredBold>
+                    </div>
+                </div>
                 <br />
                 {<NextEpisodeButton />}
             </div>

--- a/src/components/episode/scenes/botbNomCeremonyScene.tsx
+++ b/src/components/episode/scenes/botbNomCeremonyScene.tsx
@@ -7,6 +7,7 @@ import { Centered, CenteredBold } from "../../layout/centered";
 import { DividerBox } from "../../layout/box";
 import { backdoorNPlayers } from "../../../utils/ai/aiApi";
 import { listNames } from "../../../utils/listStrings";
+import { ProfileHouseguest } from "../../memoryWall";
 
 export function generateBotbNomCeremonyScene(
     initialGameState: GameState,
@@ -37,6 +38,34 @@ export function generateBotbNomCeremonyScene(
         `I have nominated you, ${listNames(noms.map((n) => n.name))} for eviction. `;
     const firstText = "My first nominee is...";
     const secondText = "My second nominee is...";
+
+    const block = (noms: Houseguest[], hoh: ProfileHouseguest) => {
+        return (
+            <div className="column">
+                <div className="column">
+                    <div className="columns is-centered">
+                        <div className="column">
+                            <Portrait centered={true} houseguest={hoh} />
+                        </div>
+                    </div>
+                    <div className="columns is-centered">
+                        <DividerBox className="column is-5">
+                            <Centered> {firstText}</Centered>
+                            <Portrait centered={true} houseguest={noms[0]} />
+                        </DividerBox>
+                        <DividerBox className="column is-5">
+                            <Centered> {secondText}</Centered>
+                            <Portrait centered={true} houseguest={noms[1]} />
+                        </DividerBox>
+                    </div>
+                </div>
+                <div className="column">
+                    <CenteredBold>{finalStatement(noms)}</CenteredBold>
+                </div>
+            </div>
+        );
+    };
+
     const scene = new Scene({
         title: "Nomination Ceremony",
         gameState: newGameState,
@@ -46,42 +75,12 @@ export function generateBotbNomCeremonyScene(
                     This is the nomination ceremony. It is our responsibility as Heads of Household to each
                     nominate two houseguests for eviction.
                 </Centered>
-                <div className="columns is-marginless is-centered is-mobile">
-                    <div className="column">
-                        <Portrait centered={true} houseguest={hoh1} />
-                    </div>
-                    <div className="column">
-                        <Portrait centered={true} houseguest={hoh2} />
-                    </div>
-                </div>
                 <div className="columns is-marginless is-centered">
-                    <DividerBox className="column">
-                        <Centered>{firstText}</Centered>
-                        <Portrait centered={true} houseguest={noms1[0]} />
-                    </DividerBox>
-                    <DividerBox className="column">
-                        <Centered>{secondText}</Centered>
-                        <Portrait centered={true} houseguest={noms1[1]} />
-                    </DividerBox>
-                    <DividerBox className="column">
-                        <Centered>{firstText}</Centered>
-                        <Portrait centered={true} houseguest={noms2[0]} />
-                    </DividerBox>
-                    <DividerBox className="column">
-                        <Centered>{secondText}</Centered>
-                        <Portrait centered={true} houseguest={noms2[1]} />
-                    </DividerBox>
-                </div>
-                <div className="columns is-marginless is-centered is-mobile">
-                    <div className="column">
-                        <CenteredBold>{finalStatement(noms1)}</CenteredBold>
-                    </div>
-                    <div className="column">
-                        <CenteredBold>{finalStatement(noms2)}</CenteredBold>
-                    </div>
+                    {block(noms1, hoh1)}
+                    {block(noms2, hoh2)}
                 </div>
                 <br />
-                {<NextEpisodeButton />}
+                <NextEpisodeButton />
             </div>
         ),
     });

--- a/src/components/episode/scenes/botbNomCeremonyScene.tsx
+++ b/src/components/episode/scenes/botbNomCeremonyScene.tsx
@@ -1,6 +1,6 @@
 import { GameState, Houseguest, MutableGameState, getById, exclude } from "../../../model";
 import { Scene } from "./scene";
-import { Portrait, Portraits } from "../../playerPortrait/portraits";
+import { Portrait } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";

--- a/src/components/episode/scenes/botbNomCeremonyScene.tsx
+++ b/src/components/episode/scenes/botbNomCeremonyScene.tsx
@@ -1,0 +1,80 @@
+import { GameState, Houseguest, MutableGameState, getById, exclude } from "../../../model";
+import { Scene } from "./scene";
+import { Portrait, Portraits } from "../../playerPortrait/portraits";
+import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
+import React from "react";
+import { Centered, CenteredBold } from "../../layout/centered";
+import { DividerBox } from "../../layout/box";
+import { backdoorNPlayers } from "../../../utils/ai/aiApi";
+import { listNames } from "../../../utils/listStrings";
+
+export function generateBotbNomCeremonyScene(
+    initialGameState: GameState,
+    hoh1: Houseguest,
+    hoh2: Houseguest
+): [GameState, Scene, Houseguest[][]] {
+    const newGameState = new MutableGameState(initialGameState);
+
+    const exclusions = [hoh1, hoh2];
+    const noms1: Houseguest[] = [];
+    const noms2: Houseguest[] = [];
+    for (let i = 0; i < 4; i++) {
+        const hoh = i % 2 === 0 ? hoh1 : hoh2;
+        const nextNom: Houseguest = getById(
+            newGameState,
+            backdoorNPlayers(hoh, exclude(newGameState.houseguests, exclusions), newGameState, 1)[0].decision
+        );
+        exclusions.push(nextNom);
+        i % 2 === 0 ? noms1.push(nextNom) : noms2.push(nextNom);
+    }
+    [noms1, noms2].forEach((arr) => arr.forEach((nom) => nom.nominations++));
+    newGameState.currentLog.nominationsPreVeto = [...noms1, ...noms2].map((nom) => nom.name);
+
+    newGameState.currentLog.nominationsPreVeto = require("alphanum-sort")(
+        newGameState.currentLog.nominationsPreVeto
+    );
+    const finalStatement = (noms: Houseguest[]) =>
+        `I have nominated you, ${listNames(noms.map((n) => n.name))} for eviction. `;
+    const firstText = "My first nominee is...";
+    const secondText = "My second nominee is...";
+    const scene = new Scene({
+        title: "Nomination Ceremony",
+        gameState: newGameState,
+        content: (
+            <div>
+                <Centered>
+                    This is the nomination ceremony. It is our responsibility as Heads of Household to each
+                    nominate two houseguests for eviction.
+                </Centered>
+                <Portraits centered={true} houseguests={[hoh1]} />
+                <div className="columns is-marginless is-centered">
+                    <DividerBox className="column">
+                        <Centered>{firstText}</Centered>
+                        <Portrait centered={true} houseguest={noms1[0]} />
+                    </DividerBox>
+                    <DividerBox className="column">
+                        <Centered>{secondText}</Centered>
+                        <Portrait centered={true} houseguest={noms1[1]} />
+                    </DividerBox>
+                </div>
+                <CenteredBold>{finalStatement(noms1)}</CenteredBold>
+                <div style={{ marginTop: 50 }} />
+                <Portraits centered={true} houseguests={[hoh2]} />
+                <div className="columns is-marginless is-centered">
+                    <DividerBox className="column">
+                        <Centered>{firstText}</Centered>
+                        <Portrait centered={true} houseguest={noms2[0]} />
+                    </DividerBox>
+                    <DividerBox className="column">
+                        <Centered>{secondText}</Centered>
+                        <Portrait centered={true} houseguest={noms2[1]} />
+                    </DividerBox>
+                </div>
+                <CenteredBold>{finalStatement(noms2)}</CenteredBold>
+                <br />
+                {<NextEpisodeButton />}
+            </div>
+        ),
+    });
+    return [new GameState(newGameState), scene, [noms1, noms2]];
+}

--- a/src/components/episode/scenes/botbScene.tsx
+++ b/src/components/episode/scenes/botbScene.tsx
@@ -1,24 +1,24 @@
-import { GameState, Houseguest, MutableGameState, getById, exclude } from "../../../model";
+import { GameState, Houseguest, MutableGameState } from "../../../model";
 import { Scene } from "./scene";
 import { Portrait, Portraits } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
 import { DividerBox } from "../../layout/box";
-import { backdoorNPlayers } from "../../../utils/ai/aiApi";
-import { listNames } from "../../../utils/listStrings";
 import { rng } from "../../../utils";
+import { listNames } from "../../../utils/listStrings";
 
 export function generateBotbScene(
     initialGameState: GameState,
     hohArray: Houseguest[],
     nomsArray: Houseguest[]
-): [GameState, Scene, Houseguest, Houseguest[]] {
+): [GameState, Scene, Houseguest, Houseguest[], Houseguest[]] {
     const newGameState = new MutableGameState(initialGameState);
-    console.log(hohArray, nomsArray);
     const hoh0wins = rng().flipCoin();
     const hoh = hohArray[hoh0wins ? 0 : 1];
+    newGameState.previousHOH = [hoh];
     const noms = hoh0wins ? [nomsArray[0], nomsArray[1]] : [nomsArray[2], nomsArray[3]];
+    const winners = hoh0wins ? [nomsArray[2], nomsArray[3]] : [nomsArray[0], nomsArray[1]];
     const scene = new Scene({
         title: "Battle of the Block",
         gameState: newGameState,
@@ -27,26 +27,41 @@ export function generateBotbScene(
                 <Centered>
                     {`This is the Battle of the Block competition. ${hohArray[0].name}'s nominees will battle ${hohArray[1].name}'s nominees to save themselves from the block. The winning pair will win safety for the week, and dethrone the HoH that nominated them.`}
                 </Centered>
-                <div className="columns is-marginless is-centered is-mobile">
+                <div className="columns is-centered">
                     <div className="column">
-                        <Portrait centered={true} houseguest={hohArray[0]} />
+                        <div className="columns is-centered">
+                            <div className="column">
+                                <Portrait centered={true} houseguest={hohArray[0]} />
+                            </div>
+                        </div>
+                        <div className="columns is-centered">
+                            <DividerBox className="column is-11">
+                                <Portraits centered={true} houseguests={[nomsArray[0], nomsArray[1]]} />
+                            </DividerBox>
+                        </div>
                     </div>
                     <div className="column">
-                        <Portrait centered={true} houseguest={hohArray[1]} />
+                        <div className="columns is-centered">
+                            <div className="column">
+                                <Portrait centered={true} houseguest={hohArray[1]} />
+                            </div>
+                        </div>
+                        <div className="columns is-centered">
+                            <DividerBox className="column is-11">
+                                <Portraits centered={true} houseguests={[nomsArray[2], nomsArray[3]]} />
+                            </DividerBox>
+                        </div>
                     </div>
                 </div>
-                <div className="columns is-marginless is-centered">
-                    <DividerBox className="column">
-                        <Portraits centered={true} houseguests={[nomsArray[0], nomsArray[1]]} />
-                    </DividerBox>
-                    <DividerBox className="column">
-                        <Portraits centered={true} houseguests={[nomsArray[2], nomsArray[3]]} />
-                    </DividerBox>
-                </div>
+                <Centered>...</Centered>
+                <Portraits centered={true} houseguests={winners} />
+                <CenteredBold>
+                    {`${listNames(winners.map((w) => w.name))} have won the Battle of the Block!`}
+                </CenteredBold>
                 <br />
                 {<NextEpisodeButton />}
             </div>
         ),
     });
-    return [new GameState(newGameState), scene, hoh, noms];
+    return [new GameState(newGameState), scene, hoh, noms, winners];
 }

--- a/src/components/episode/scenes/botbScene.tsx
+++ b/src/components/episode/scenes/botbScene.tsx
@@ -1,0 +1,52 @@
+import { GameState, Houseguest, MutableGameState, getById, exclude } from "../../../model";
+import { Scene } from "./scene";
+import { Portrait, Portraits } from "../../playerPortrait/portraits";
+import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
+import React from "react";
+import { Centered, CenteredBold } from "../../layout/centered";
+import { DividerBox } from "../../layout/box";
+import { backdoorNPlayers } from "../../../utils/ai/aiApi";
+import { listNames } from "../../../utils/listStrings";
+import { rng } from "../../../utils";
+
+export function generateBotbScene(
+    initialGameState: GameState,
+    hohArray: Houseguest[],
+    nomsArray: Houseguest[]
+): [GameState, Scene, Houseguest, Houseguest[]] {
+    const newGameState = new MutableGameState(initialGameState);
+    console.log(hohArray, nomsArray);
+    const hoh0wins = rng().flipCoin();
+    const hoh = hohArray[hoh0wins ? 0 : 1];
+    const noms = hoh0wins ? [nomsArray[0], nomsArray[1]] : [nomsArray[2], nomsArray[3]];
+    const scene = new Scene({
+        title: "Battle of the Block",
+        gameState: newGameState,
+        content: (
+            <div>
+                <Centered>
+                    {`This is the Battle of the Block competition. ${hohArray[0].name}'s nominees will battle ${hohArray[1].name}'s nominees to save themselves from the block. The winning pair will win safety for the week, and dethrone the HoH that nominated them.`}
+                </Centered>
+                <div className="columns is-marginless is-centered is-mobile">
+                    <div className="column">
+                        <Portrait centered={true} houseguest={hohArray[0]} />
+                    </div>
+                    <div className="column">
+                        <Portrait centered={true} houseguest={hohArray[1]} />
+                    </div>
+                </div>
+                <div className="columns is-marginless is-centered">
+                    <DividerBox className="column">
+                        <Portraits centered={true} houseguests={[nomsArray[0], nomsArray[1]]} />
+                    </DividerBox>
+                    <DividerBox className="column">
+                        <Portraits centered={true} houseguests={[nomsArray[2], nomsArray[3]]} />
+                    </DividerBox>
+                </div>
+                <br />
+                {<NextEpisodeButton />}
+            </div>
+        ),
+    });
+    return [new GameState(newGameState), scene, hoh, noms];
+}

--- a/src/components/episode/scenes/botbScene.tsx
+++ b/src/components/episode/scenes/botbScene.tsx
@@ -20,34 +20,27 @@ export function generateBotbScene(
     const noms = hoh0wins ? [nomsArray[0], nomsArray[1]] : [nomsArray[2], nomsArray[3]];
     const winners = hoh0wins ? [nomsArray[2], nomsArray[3]] : [nomsArray[0], nomsArray[1]];
 
-    const block0 = (
-        <div className="column">
-            <div className="columns is-centered">
-                <div className="column">
-                    <Portrait centered={true} houseguest={hohArray[0]} />
+    const block = (hohIndex: number, nomIndex: number) => {
+        return (
+            <div className="column">
+                <div className="columns is-centered">
+                    <div className="column">
+                        <Portrait centered={true} houseguest={hohArray[hohIndex]} />
+                    </div>
+                </div>
+                <div className="columns is-centered">
+                    <DividerBox className={`column is-11`}>
+                        <Portraits
+                            centered={true}
+                            houseguests={[nomsArray[nomIndex], nomsArray[nomIndex + 1]]}
+                        />
+                    </DividerBox>
                 </div>
             </div>
-            <div className="columns is-centered">
-                <DividerBox className="column is-11">
-                    <Portraits centered={true} houseguests={[nomsArray[0], nomsArray[1]]} />
-                </DividerBox>
-            </div>
-        </div>
-    );
-    const block1 = (
-        <div className="column">
-            <div className="columns is-centered">
-                <div className="column">
-                    <Portrait centered={true} houseguest={hohArray[1]} />
-                </div>
-            </div>
-            <div className="columns is-centered">
-                <DividerBox className="column is-11">
-                    <Portraits centered={true} houseguests={[nomsArray[2], nomsArray[3]]} />
-                </DividerBox>
-            </div>
-        </div>
-    );
+        );
+    };
+    const block0 = block(0, 0);
+    const block1 = block(1, 2);
 
     const scene = new Scene({
         title: "Battle of the Block",
@@ -65,7 +58,23 @@ export function generateBotbScene(
                 <CenteredBold>
                     {`${listNames(winners.map((w) => w.name))} have won the Battle of the Block!`}
                 </CenteredBold>
-                {hoh0wins ? block0 : block1}
+
+                <div className="column">
+                    <div className="columns is-centered">
+                        <div className="column">
+                            <Portrait centered={true} houseguest={hoh} />
+                        </div>
+                    </div>
+                    <div className="columns is-centered">
+                        <DividerBox className="column is-5">
+                            <Portrait centered={true} houseguest={noms[0]} />
+                        </DividerBox>
+                        <DividerBox className="column is-5">
+                            <Portrait centered={true} houseguest={noms[1]} />
+                        </DividerBox>
+                    </div>
+                </div>
+
                 <CenteredBold>
                     {`${listNames([hoh.name])} will remain as HoH, with ${listNames(
                         noms.map((n) => n.name)

--- a/src/components/episode/scenes/botbScene.tsx
+++ b/src/components/episode/scenes/botbScene.tsx
@@ -19,6 +19,36 @@ export function generateBotbScene(
     newGameState.previousHOH = [hoh];
     const noms = hoh0wins ? [nomsArray[0], nomsArray[1]] : [nomsArray[2], nomsArray[3]];
     const winners = hoh0wins ? [nomsArray[2], nomsArray[3]] : [nomsArray[0], nomsArray[1]];
+
+    const block0 = (
+        <div className="column">
+            <div className="columns is-centered">
+                <div className="column">
+                    <Portrait centered={true} houseguest={hohArray[0]} />
+                </div>
+            </div>
+            <div className="columns is-centered">
+                <DividerBox className="column is-11">
+                    <Portraits centered={true} houseguests={[nomsArray[0], nomsArray[1]]} />
+                </DividerBox>
+            </div>
+        </div>
+    );
+    const block1 = (
+        <div className="column">
+            <div className="columns is-centered">
+                <div className="column">
+                    <Portrait centered={true} houseguest={hohArray[1]} />
+                </div>
+            </div>
+            <div className="columns is-centered">
+                <DividerBox className="column is-11">
+                    <Portraits centered={true} houseguests={[nomsArray[2], nomsArray[3]]} />
+                </DividerBox>
+            </div>
+        </div>
+    );
+
     const scene = new Scene({
         title: "Battle of the Block",
         gameState: newGameState,
@@ -28,35 +58,18 @@ export function generateBotbScene(
                     {`This is the Battle of the Block competition. ${hohArray[0].name}'s nominees will battle ${hohArray[1].name}'s nominees to save themselves from the block. The winning pair will win safety for the week, and dethrone the HoH that nominated them.`}
                 </Centered>
                 <div className="columns is-centered">
-                    <div className="column">
-                        <div className="columns is-centered">
-                            <div className="column">
-                                <Portrait centered={true} houseguest={hohArray[0]} />
-                            </div>
-                        </div>
-                        <div className="columns is-centered">
-                            <DividerBox className="column is-11">
-                                <Portraits centered={true} houseguests={[nomsArray[0], nomsArray[1]]} />
-                            </DividerBox>
-                        </div>
-                    </div>
-                    <div className="column">
-                        <div className="columns is-centered">
-                            <div className="column">
-                                <Portrait centered={true} houseguest={hohArray[1]} />
-                            </div>
-                        </div>
-                        <div className="columns is-centered">
-                            <DividerBox className="column is-11">
-                                <Portraits centered={true} houseguests={[nomsArray[2], nomsArray[3]]} />
-                            </DividerBox>
-                        </div>
-                    </div>
+                    {block0} {block1}
                 </div>
                 <Centered>...</Centered>
                 <Portraits centered={true} houseguests={winners} />
                 <CenteredBold>
                     {`${listNames(winners.map((w) => w.name))} have won the Battle of the Block!`}
+                </CenteredBold>
+                {hoh0wins ? block0 : block1}
+                <CenteredBold>
+                    {`${listNames([hoh.name])} will remain as HoH, with ${listNames(
+                        noms.map((n) => n.name)
+                    )} as nominees.`}
                 </CenteredBold>
                 <br />
                 {<NextEpisodeButton />}

--- a/src/components/episode/scenes/botbScene.tsx
+++ b/src/components/episode/scenes/botbScene.tsx
@@ -7,6 +7,7 @@ import { Centered, CenteredBold } from "../../layout/centered";
 import { DividerBox } from "../../layout/box";
 import { rng } from "../../../utils";
 import { listNames } from "../../../utils/listStrings";
+import { HoHVote } from "../../../model/logging/voteType";
 
 export function generateBotbScene(
     initialGameState: GameState,
@@ -17,6 +18,7 @@ export function generateBotbScene(
     const hoh0wins = rng().flipCoin();
     const hoh = hohArray[hoh0wins ? 0 : 1];
     newGameState.previousHOH = [hoh];
+    newGameState.currentLog.votes[hoh.id] = new HoHVote();
     const noms = hoh0wins ? [nomsArray[0], nomsArray[1]] : [nomsArray[2], nomsArray[3]];
     const winners = hoh0wins ? [nomsArray[2], nomsArray[3]] : [nomsArray[0], nomsArray[1]];
 

--- a/src/components/episode/scenes/hohCompScene.tsx
+++ b/src/components/episode/scenes/hohCompScene.tsx
@@ -27,9 +27,15 @@ export function generateHohCompScene(
     const newHoH2: Houseguest = options.coHoH
         ? randomPlayer(newGameState.houseguests, [newHoH, ...previousHoh])
         : newHoH;
+    // set previous hoh
     (!coHoH || coHohIsFinal) && (newGameState.previousHOH = [newHoH]);
+    coHoH && coHohIsFinal && (newGameState.previousHOH = [newHoH, newHoH2]);
+    // add hoh vote in whatever
     (!coHoH || coHohIsFinal) && (newGameState.currentLog.votes[newHoH.id] = new HoHVote());
+    coHoH && coHohIsFinal && (newGameState.currentLog.votes[newHoH2.id] = new HoHVote());
+    // new hoh wins
     (!coHoH || coHohIsFinal) && (newHoH.hohWins += 1);
+    coHoH && coHohIsFinal && (newHoH2.hohWins += 1);
 
     const portraitLine = coHoH ? (
         <Portraits centered={true} houseguests={[newHoH, newHoH2]} />

--- a/src/components/episode/scenes/hohCompScene.tsx
+++ b/src/components/episode/scenes/hohCompScene.tsx
@@ -34,8 +34,8 @@ export function generateHohCompScene(
     (!coHoH || coHohIsFinal) && (newGameState.currentLog.votes[newHoH.id] = new HoHVote());
     coHoH && coHohIsFinal && (newGameState.currentLog.votes[newHoH2.id] = new HoHVote());
     // new hoh wins
-    (!coHoH || coHohIsFinal) && (newHoH.hohWins += 1);
-    coHoH && coHohIsFinal && (newHoH2.hohWins += 1);
+    newHoH.hohWins += 1;
+    coHoH && (newHoH2.hohWins += 1);
 
     const portraitLine = coHoH ? (
         <Portraits centered={true} houseguests={[newHoH, newHoH2]} />

--- a/src/components/episode/scenes/hohCompScene.tsx
+++ b/src/components/episode/scenes/hohCompScene.tsx
@@ -1,27 +1,45 @@
 import { GameState, Houseguest, MutableGameState, randomPlayer } from "../../../model";
 import { Scene } from "./scene";
-import { Portrait } from "../../playerPortrait/portraits";
+import { Portrait, Portraits } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
 import { HoHVote } from "../../../model/logging/voteType";
+import { listNames } from "../../../utils/listStrings";
 
 interface HohCompOptions {
-    doubleEviction: boolean;
+    doubleEviction?: boolean;
     customText?: string;
+    coHoH?: boolean;
+    coHohIsFinal?: boolean;
 }
 
 export function generateHohCompScene(
     initialGameState: GameState,
     options: HohCompOptions
-): [GameState, Scene, Houseguest] {
+): [GameState, Scene, Houseguest[]] {
     const newGameState = new MutableGameState(initialGameState);
-    const doubleEviction = options.doubleEviction;
-    const previousHoh = initialGameState.previousHOH ? [initialGameState.previousHOH] : [];
+    const coHoH = options.coHoH || false;
+    const coHohIsFinal = options.coHohIsFinal || false;
+    const doubleEviction: boolean = options.doubleEviction || false;
+    const previousHoh = initialGameState.previousHOH ? initialGameState.previousHOH : [];
     const newHoH: Houseguest = randomPlayer(newGameState.houseguests, previousHoh);
-    newGameState.previousHOH = newHoH;
-    newGameState.currentLog.votes[newHoH.id] = new HoHVote();
-    newHoH.hohWins += 1;
+    const newHoH2: Houseguest = options.coHoH
+        ? randomPlayer(newGameState.houseguests, [newHoH, ...previousHoh])
+        : newHoH;
+    (!coHoH || coHohIsFinal) && (newGameState.previousHOH = [newHoH]);
+    (!coHoH || coHohIsFinal) && (newGameState.currentLog.votes[newHoH.id] = new HoHVote());
+    (!coHoH || coHohIsFinal) && (newHoH.hohWins += 1);
+
+    const portraitLine = coHoH ? (
+        <Portraits centered={true} houseguests={[newHoH, newHoH2]} />
+    ) : (
+        <Portrait centered={true} houseguest={newHoH} />
+    );
+    const wonText = `${coHoH ? listNames([newHoH.name, newHoH2.name]) : newHoH.name} ${
+        coHoH ? "have" : "has"
+    } won Head of Household!`;
+
     const scene = new Scene({
         title: "HoH Competition",
         gameState: initialGameState,
@@ -38,17 +56,19 @@ export function generateHohCompScene(
                         </CenteredBold>
                     ) : (
                         <Centered>
-                            {`Houseguests, it's time to find a new Head of Household. As outgoing HoH, ${previousHoh[0].name} will not compete.`}
+                            {`Houseguests, it's time to find a new Head of Household. As outgoing HoH, ${listNames(
+                                previousHoh.map((h) => h.name)
+                            )} will not compete.`}
                         </Centered>
                     ))
                 )}
-                <Portrait centered={true} houseguest={newHoH} />
-                <CenteredBold>{newHoH.name} has won Head of Household!</CenteredBold>
+                {portraitLine}
+                <CenteredBold>{wonText}</CenteredBold>
                 <br />
                 {!doubleEviction && <NextEpisodeButton />}
             </div>
         ),
     });
 
-    return [new GameState(newGameState), scene, newHoH];
+    return [new GameState(newGameState), scene, coHoH ? [newHoH, newHoH2] : [newHoH]];
 }

--- a/src/components/episode/scenes/nomCeremonyScene.tsx
+++ b/src/components/episode/scenes/nomCeremonyScene.tsx
@@ -37,8 +37,12 @@ export function generateNomCeremonyScene(
     const nom2 = coHoH
         ? getById(
               newGameState,
-              backdoorNPlayers(coHoH, exclude(newGameState.houseguests, [HoH, nom1]), newGameState, 1)[0]
-                  .decision
+              backdoorNPlayers(
+                  coHoH,
+                  exclude(newGameState.houseguests, [HoH, coHoH, nom1]),
+                  newGameState,
+                  1
+              )[0].decision
           )
         : getById(
               newGameState,

--- a/src/components/episode/scenes/nomCeremonyScene.tsx
+++ b/src/components/episode/scenes/nomCeremonyScene.tsx
@@ -15,12 +15,35 @@ interface NomCeremonyOptions {
 
 export function generateNomCeremonyScene(
     initialGameState: GameState,
-    HoH: Houseguest,
+    hohList: Houseguest[],
     options: NomCeremonyOptions
 ): [GameState, Scene, Houseguest[]] {
     const newGameState = new MutableGameState(initialGameState);
+    const HoH = hohList[0];
+    const coHoH = hohList.length > 1 ? hohList[1] : undefined;
     const doubleEviction = options.doubleEviction;
-    const [nom1, nom2] = [getById(newGameState, HoH.targets[0]), getById(newGameState, HoH.targets[1])];
+
+    const nom1: Houseguest = getById(
+        newGameState,
+        backdoorNPlayers(
+            HoH,
+            exclude(newGameState.houseguests, coHoH ? [HoH, coHoH] : [HoH]),
+            newGameState,
+            1
+        )[0].decision
+    );
+
+    const nom2 = coHoH
+        ? getById(
+              newGameState,
+              backdoorNPlayers(coHoH, exclude(newGameState.houseguests, [HoH, nom1]), newGameState, 1)[0]
+                  .decision
+          )
+        : getById(
+              newGameState,
+              backdoorNPlayers(HoH, exclude(newGameState.houseguests, [HoH, nom1]), newGameState, 1)[0]
+                  .decision
+          );
     nom1.nominations++;
     nom2.nominations++;
     newGameState.currentLog.nominationsPreVeto = [nom1.name, nom2.name];

--- a/src/components/episode/scenes/nomCeremonyScene.tsx
+++ b/src/components/episode/scenes/nomCeremonyScene.tsx
@@ -1,15 +1,16 @@
 import { GameState, Houseguest, MutableGameState, getById, exclude } from "../../../model";
 import { Scene } from "./scene";
 import { shuffle } from "lodash";
-import { Portrait } from "../../playerPortrait/portraits";
+import { Portrait, Portraits } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
 import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
 import { DividerBox } from "../../layout/box";
 import { backdoorNPlayers } from "../../../utils/ai/aiApi";
+import { listNames } from "../../../utils/listStrings";
 
 interface NomCeremonyOptions {
-    doubleEviction: boolean;
+    doubleEviction?: boolean;
     thirdNominee?: boolean;
 }
 
@@ -21,7 +22,7 @@ export function generateNomCeremonyScene(
     const newGameState = new MutableGameState(initialGameState);
     const HoH = hohList[0];
     const coHoH = hohList.length > 1 ? hohList[1] : undefined;
-    const doubleEviction = options.doubleEviction;
+    const doubleEviction = options.doubleEviction || false;
 
     const nom1: Houseguest = getById(
         newGameState,
@@ -60,10 +61,14 @@ export function generateNomCeremonyScene(
     newGameState.currentLog.nominationsPreVeto = require("alphanum-sort")(
         newGameState.currentLog.nominationsPreVeto
     );
-    const noms = nom3 ? shuffle([nom1, nom2, nom3]) : shuffle([nom1, nom2]);
-    const finalStatement = options.thirdNominee
-        ? `I have nominated you, ${noms[0].name}, ${noms[1].name}, and ${noms[2].name} for eviction. `
-        : `I have nominated you, ${noms[0].name} and you, ${noms[1].name} for eviction.`;
+    const shuffleOrDont = coHoH ? (a: Houseguest[]): Houseguest[] => a : shuffle;
+    const noms = nom3 ? shuffleOrDont([nom1, nom2, nom3]) : shuffleOrDont([nom1, nom2]);
+    const weI = coHoH ? "We" : "I";
+    const finalStatement = `${weI} have nominated you, ${listNames(noms.map((n) => n.name))} for eviction. `;
+    const myOur = coHoH ? "our" : "my";
+    const theHoH = coHoH ? "Heads of Household" : "the Head of Household";
+    const firstText = coHoH ? `${HoH.name} has nominated...` : "My first nominee is...";
+    const secondText = coHoH ? `${coHoH.name} has nominated...` : "My second nominee is...";
     const scene = new Scene({
         title: "Nomination Ceremony",
         gameState: newGameState,
@@ -71,17 +76,17 @@ export function generateNomCeremonyScene(
             <div>
                 <Centered>
                     {!doubleEviction &&
-                        `This is the nomination ceremony. It is my responsibility as the Head of Household to
+                        `This is the nomination ceremony. It is ${myOur} responsibility as ${theHoH} to
                     nominate ${options.thirdNominee ? `three` : `two`} houseguests for eviction.`}
                 </Centered>
-                {!doubleEviction && <Portrait centered={true} houseguest={HoH} />}
+                {!doubleEviction && <Portraits centered={true} houseguests={hohList} />}
                 <div className="columns is-marginless is-centered">
                     <DividerBox className="column">
-                        <Centered> My first nominee is...</Centered>
+                        <Centered>{firstText}</Centered>
                         <Portrait centered={true} houseguest={noms[0]} />
                     </DividerBox>
                     <DividerBox className="column">
-                        <Centered>My second nominee is...</Centered>
+                        <Centered>{secondText}</Centered>
                         <Portrait centered={true} houseguest={noms[1]} />
                     </DividerBox>
                     {options.thirdNominee && (

--- a/src/components/episode/scenes/safetyChainScene.tsx
+++ b/src/components/episode/scenes/safetyChainScene.tsx
@@ -8,60 +8,57 @@ import { Portrait, Portraits } from "../../playerPortrait/portraits";
 import { Scene } from "./scene";
 import { evictHouseguest } from "../utilities/evictHouseguest";
 
-export function generateSafetyChainScene(initialGameState: GameState): [GameState, Scene] {
-    const newGameState = new MutableGameState(initialGameState);
-    const chainOrder: Houseguest[] = [];
-    const chainStarter: Houseguest = randomPlayer(newGameState.houseguests);
-    const options: Houseguest[] = nonEvictedHouseguests(newGameState).filter(
-        (hg) => hg.id !== chainStarter.id
-    );
-
-    chainOrder.push(chainStarter);
-    const safeSpots = newGameState.nonEvictedHouseguests.size - 1;
-    let currentChooser: Houseguest = chainStarter;
-    const sceneContent: JSX.Element[] = [];
-    let first = true;
-    while (chainOrder.length < safeSpots) {
-        const newSafeIndex = getBestFriend(currentChooser, options);
-        chainOrder.push(options[newSafeIndex]);
-        newGameState.currentLog.votes[currentChooser.id] = first
-            ? new HoHVote(options[newSafeIndex].id)
-            : new NormalVote(options[newSafeIndex].id);
-        first = false;
-        options.splice(newSafeIndex, 1);
-        sceneContent.push(
-            <Centered key={`safetychain-${newGameState.phase}-${chainOrder.length}`}>
-                {currentChooser.name} has chosen {chainOrder[chainOrder.length - 1].name}!
-                <Portraits
-                    houseguests={[currentChooser, chainOrder[chainOrder.length - 1]]}
-                    centered={true}
-                />
-            </Centered>
-        );
-        currentChooser = chainOrder[chainOrder.length - 1];
-    }
-    newGameState.currentLog.soleVoter = chainOrder[chainOrder.length - 2].name;
-    newGameState.currentLog.votes[chainOrder[chainOrder.length - 1].id] = new NomineeVote(false);
-    newGameState.currentLog.votes[options[0].id] = new NomineeVote(true);
-    newGameState.currentLog.nominationsPostVeto = [options[0].name, chainOrder[chainOrder.length - 1].name];
-
-    sceneContent.push(
-        <Centered key={`safetychain-final-${newGameState.phase}-${chainOrder.length}`}>
-            {options[0].name} has been left out!
-            <Portrait houseguest={options[0]} centered={true} />
-        </Centered>
-    );
-    evictHouseguest(newGameState, options[0].id); // TODO: newGameState = evicthouseguest...
-    const scene: Scene = new Scene({
-        title: "Chain Ceremony",
-        gameState: initialGameState,
-        content: (
-            <div>
-                {sceneContent}
-                <NextEpisodeButton />
-            </div>
-        ),
-    });
-
-    return [newGameState, scene];
+export function generateSafetyChainScene(initialGameState: GameState): void {
+    // const newGameState = new MutableGameState(initialGameState);
+    // const chainOrder: Houseguest[] = [];
+    // const chainStarter: Houseguest = randomPlayer(newGameState.houseguests);
+    // const options: Houseguest[] = nonEvictedHouseguests(newGameState).filter(
+    //     (hg) => hg.id !== chainStarter.id
+    // );
+    // chainOrder.push(chainStarter);
+    // const safeSpots = newGameState.nonEvictedHouseguests.size - 1;
+    // let currentChooser: Houseguest = chainStarter;
+    // const sceneContent: JSX.Element[] = [];
+    // let first = true;
+    // while (chainOrder.length < safeSpots) {
+    //     const newSafeIndex = getBestFriend(currentChooser, options);
+    //     chainOrder.push(options[newSafeIndex]);
+    //     newGameState.currentLog.votes[currentChooser.id] = first
+    //         ? new HoHVote(options[newSafeIndex].id)
+    //         : new NormalVote(options[newSafeIndex].id);
+    //     first = false;
+    //     options.splice(newSafeIndex, 1);
+    //     sceneContent.push(
+    //         <Centered key={`safetychain-${newGameState.phase}-${chainOrder.length}`}>
+    //             {currentChooser.name} has chosen {chainOrder[chainOrder.length - 1].name}!
+    //             <Portraits
+    //                 houseguests={[currentChooser, chainOrder[chainOrder.length - 1]]}
+    //                 centered={true}
+    //             />
+    //         </Centered>
+    //     );
+    //     currentChooser = chainOrder[chainOrder.length - 1];
+    // }
+    // newGameState.currentLog.soleVoter = chainOrder[chainOrder.length - 2].name;
+    // newGameState.currentLog.votes[chainOrder[chainOrder.length - 1].id] = new NomineeVote(false);
+    // newGameState.currentLog.votes[options[0].id] = new NomineeVote(true);
+    // newGameState.currentLog.nominationsPostVeto = [options[0].name, chainOrder[chainOrder.length - 1].name];
+    // sceneContent.push(
+    //     <Centered key={`safetychain-final-${newGameState.phase}-${chainOrder.length}`}>
+    //         {options[0].name} has been left out!
+    //         <Portrait houseguest={options[0]} centered={true} />
+    //     </Centered>
+    // );
+    // evictHouseguest(newGameState, options[0].id); // TODO: newGameState = evicthouseguest...
+    // const scene: Scene = new Scene({
+    //     title: "Chain Ceremony",
+    //     gameState: initialGameState,
+    //     content: (
+    //         <div>
+    //             {sceneContent}
+    //             <NextEpisodeButton />
+    //         </div>
+    //     ),
+    // });
+    // return [newGameState, scene];
 }

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -16,7 +16,8 @@ export function generateVetoCeremonyScene(
     initialNominees: Houseguest[],
     povWinner: Houseguest,
     doubleEviction: boolean,
-    veto: Veto
+    veto: Veto,
+    immuneHgs: Houseguest[]
 ): [GameState, Scene, Houseguest[]] {
     let povTarget: Houseguest | null = null;
     let descisionText = "";
@@ -61,10 +62,11 @@ export function generateVetoCeremonyScene(
             HoH,
             ...initialNominees,
             povWinner,
+            ...immuneHgs,
             coHoH || HoH,
         ]);
         if (exclusion.length === 0) {
-            exclusion = exclude(initialGameState.houseguests, [HoH, ...initialNominees]);
+            exclusion = exclude(initialGameState.houseguests, [HoH, ...initialNominees, ...immuneHgs]);
         }
         const replacementCount = veto === BoomerangVeto ? 2 : 1;
         const replacementNoms = backdoorNPlayers(

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -53,11 +53,10 @@ export function generateVetoCeremonyScene(
         const HoHwonPoV = HoH.id === povWinner.id && !coHoH;
         const aReplacementNominee = veto === BoomerangVeto ? "replacement nominees" : "a replacement nominee";
         const oneOf = veto !== BoomerangVeto ? "one of " : "";
+        const you = veto === DiamondVeto ? "I" : "you";
         nameAReplacement += HoHwonPoV
             ? `Since I have just vetoed one of my nominations, I must name ${aReplacementNominee}.`
-            : `${HoHnamer.name}, since I have just vetoed ${oneOf}your nominations, ${
-                  veto === DiamondVeto ? "I" : "you"
-              } must name ${aReplacementNominee}.`;
+            : `${HoHnamer.name}, since I have just vetoed ${oneOf}your nominations, ${you} must name ${aReplacementNominee}.`;
         // if the exclusion yielded no options, you may be forced to name the veto winner as a replacement
         let exclusion = exclude(initialGameState.houseguests, [
             HoH,

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -27,7 +27,7 @@ export function generateVetoCeremonyScene(
     const HoH = hohArray[0];
     const coHoH = hohArray.length > 1 ? hohArray[1] : undefined;
 
-    const vetoChoice = veto.use(povWinner, initialNominees, initialGameState, HoH.id);
+    const vetoChoice = veto.use(povWinner, initialNominees, initialGameState, coHoH ? -1 : HoH.id);
 
     let nomineeWonPov = false;
     initialNominees.forEach((nom) => nom.id === povWinner.id && (nomineeWonPov = true));

--- a/src/components/episode/scenes/vetoCeremonyScene.tsx
+++ b/src/components/episode/scenes/vetoCeremonyScene.tsx
@@ -50,13 +50,14 @@ export function generateVetoCeremonyScene(
     const HoHnamer = coHoH && povTarget ? (povTarget.id === initialNominees[1].id ? coHoH : HoH) : HoH;
     const replacementNomineeNamer = veto === DiamondVeto ? povWinner : HoHnamer;
     if (povTarget) {
-        const HoHwonPoV = HoH.id === povWinner.id;
+        const HoHwonPoV = HoH.id === povWinner.id && !coHoH;
         const aReplacementNominee = veto === BoomerangVeto ? "replacement nominees" : "a replacement nominee";
+        const oneOf = veto !== BoomerangVeto ? "one of " : "";
         nameAReplacement += HoHwonPoV
             ? `Since I have just vetoed one of my nominations, I must name ${aReplacementNominee}.`
-            : `${HoHnamer.name}, since I have just vetoed ${
-                  veto !== BoomerangVeto ? "one of " : ""
-              }your nominations, ${veto === DiamondVeto ? "I" : "you"} must name ${aReplacementNominee}.`;
+            : `${HoHnamer.name}, since I have just vetoed ${oneOf}your nominations, ${
+                  veto === DiamondVeto ? "I" : "you"
+              } must name ${aReplacementNominee}.`;
         // if the exclusion yielded no options, you may be forced to name the veto winner as a replacement
         let exclusion = exclude(initialGameState.houseguests, [
             HoH,

--- a/src/components/episode/scenes/vetoCompScene.tsx
+++ b/src/components/episode/scenes/vetoCompScene.tsx
@@ -16,7 +16,7 @@ import { Veto } from "../veto/veto";
 
 export function generateVetoCompScene(
     initialGameState: GameState,
-    HoH: Houseguest,
+    HoHs: Houseguest[],
     nominees: Houseguest[],
     veto: Veto,
     doubleEviction: boolean = false
@@ -29,13 +29,13 @@ export function generateVetoCompScene(
     const everyoneWillPlay = choices.length <= 6;
 
     if (everyoneWillPlay) {
-        povPlayers.push({ ...HoH });
+        HoHs.forEach((hoh) => povPlayers.push({ ...hoh }));
         nominees.forEach((nominee) => povPlayers.push({ ...nominee }));
         while (povPlayers.length < choices.length) {
             povPlayers.push({ ...randomPlayer(choices, povPlayers) });
         }
     } else {
-        povPlayers.push({ ...HoH });
+        HoHs.forEach((hoh) => povPlayers.push({ ...hoh }));
         nominees.forEach((nominee) => povPlayers.push({ ...nominee }));
         while (povPlayers.length < 6) {
             povPlayers.push({ ...randomPlayer(choices, povPlayers) });
@@ -49,7 +49,7 @@ export function generateVetoCompScene(
     if (everyoneWillPlay) {
         introText = "Everyone left in the house will compete in this challenge.";
     } else {
-        introText = `${HoH.name}, as Head of Household, and ${listNames(
+        introText = `${listNames(HoHs.map((h) => h.name))}, as Head of Household, and ${listNames(
             nominees.map((nom) => nom.name)
         )} as nominees, will compete, as well as ${6 - 1 - nominees.length} others chosen by random draw.`; // this line assumes hoh plays in veto (-1)
     }

--- a/src/components/episode/scenes/votingTable.tsx
+++ b/src/components/episode/scenes/votingTable.tsx
@@ -49,6 +49,9 @@ export const NomineeCell = styled(EndgameTableCell)`
 export const HohCell = styled(EndgameTableCell)`
     background-color: ${({ theme }: { theme: ColorTheme }) => theme.hohCell};
 `;
+export const PoVCell = styled(EndgameTableCell)`
+    background-color: #78773f;
+`;
 
 const BlackRow = styled.tr`
     height: 0.4em;

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -47,7 +47,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
     let povWinner: Houseguest;
     [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
         currentGameState,
-        hoh,
+        [hoh],
         nominees,
         GoldenVeto,
         true
@@ -58,7 +58,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
 
     [currentGameState, vetoCeremonyScene, nominees] = generateVetoCeremonyScene(
         currentGameState,
-        hoh,
+        [hoh],
         nominees,
         povWinner,
         true,

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -63,7 +63,8 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
         nominees,
         povWinner,
         true,
-        GoldenVeto
+        GoldenVeto,
+        []
     );
     tripleScenes.push(vetoCeremonyScene);
 

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -67,7 +67,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
     tripleScenes.push(vetoCeremonyScene);
 
     let evictionScene;
-    [currentGameState, evictionScene] = generateEvictionScene(currentGameState, hoh, nominees, {
+    [currentGameState, evictionScene] = generateEvictionScene(currentGameState, [hoh], nominees, {
         doubleEviction: true,
         votingTo: "Save",
     });

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -25,18 +25,19 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
 
     currentGameState.incrementLogIndex();
 
-    let hoh: Houseguest;
+    let hohArray: Houseguest[];
     let hohCompScene: Scene;
     const tripleScenes: Scene[] = [];
-    [currentGameState, hohCompScene, hoh] = generateHohCompScene(currentGameState, {
+    [currentGameState, hohCompScene, hohArray] = generateHohCompScene(currentGameState, {
         doubleEviction: true,
         customText: "Houseguests, please return to the living room. Tonight will be a triple eviction.",
     });
     tripleScenes.push(hohCompScene);
+    const hoh = hohArray[0];
 
     let nomCeremonyScene;
     let nominees: Houseguest[];
-    [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, hoh, {
+    [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, [hoh], {
         doubleEviction: true,
         thirdNominee: true,
     });

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -85,7 +85,6 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
     return new Episode({
         gameState: new GameState(currentGameState),
         initialGamestate,
-        title: episode.title,
         scenes,
         type: TripleEvictionCad,
     });

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -16,6 +16,8 @@ export const TripleEvictionCad: EpisodeType = {
     emoji: "🇨🇦",
     hasViewsbar: true,
     name: "Triple Eviction",
+    description:
+        "A double eviction with three nominees. Houseguests vote to save one, and the other two are evicted.",
     generate: generateTripleEvictionCad,
 };
 

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -13,8 +13,9 @@ export const TripleEvictionCad: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
     eliminates: 3,
     arrowsEnabled: true,
+    emoji: "🇨🇦",
     hasViewsbar: true,
-    name: "🇨🇦 Triple Eviction",
+    name: "Triple Eviction",
     generate: generateTripleEvictionCad,
 };
 

--- a/src/components/episode/tripleEvictionEpisodeUs.tsx
+++ b/src/components/episode/tripleEvictionEpisodeUs.tsx
@@ -8,8 +8,9 @@ export const TripleEvictionUs: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
     eliminates: 3,
     arrowsEnabled: true,
+    emoji: "🇺🇸",
     hasViewsbar: true,
-    name: "🇺🇸 Triple Eviction",
+    name: "Triple Eviction",
     generate: generateTripleEvictionUs,
 };
 

--- a/src/components/episode/tripleEvictionEpisodeUs.tsx
+++ b/src/components/episode/tripleEvictionEpisodeUs.tsx
@@ -42,7 +42,6 @@ export function generateTripleEvictionUs(initialGamestate: GameState): Episode {
     return new Episode({
         gameState: new GameState(currentGameState),
         initialGamestate,
-        title: episode.title,
         scenes,
         type: TripleEvictionUs,
     });

--- a/src/components/episode/tripleEvictionEpisodeUs.tsx
+++ b/src/components/episode/tripleEvictionEpisodeUs.tsx
@@ -11,6 +11,7 @@ export const TripleEvictionUs: EpisodeType = {
     emoji: "🇺🇸",
     hasViewsbar: true,
     name: "Triple Eviction",
+    description: "Two back to back double evictions.",
     generate: generateTripleEvictionUs,
 };
 

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -136,11 +136,13 @@ function useDiamondVeto(
     hero: Houseguest,
     nominees: Houseguest[],
     gameState: GameState,
-    HoH: number
+    HoH: number,
+    skipChecks: boolean = false
 ): HouseguestWithLogic {
-    const checks = basicVetoChecks(hero, nominees, gameState, HoH);
-    if (checks) return checks;
-
+    if (!skipChecks) {
+        const checks = basicVetoChecks(hero, nominees, gameState, HoH);
+        if (checks) return checks;
+    }
     // get the 2 best targets out of the pool of all options
     const idealTargets: NumberWithLogic[] = backdoorNPlayers(
         hero,
@@ -172,7 +174,7 @@ function useDiamondVeto(
 
 function basicVetoChecks(hero: Houseguest, nominees: Houseguest[], gameState: GameState, HoH: number) {
     if (hero.id === HoH) {
-        return { decision: null, reason: "I support my original nominations." };
+        return useDiamondVeto(hero, nominees, gameState, HoH, true);
     }
     for (const nom of nominees) {
         if (hero.id === nom.id) return { decision: hero, reason: "I am going to save myself." };

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -20,17 +20,17 @@ export const GoldenVeto: Veto = {
 };
 
 export const DiamondVeto: Veto = {
-    name: "Diamond Power of Veto",
+    name: "💎 Diamond Power of Veto",
     use: useDiamondVeto,
 };
 
 export const SpotlightVeto: Veto = {
-    name: "Spotlight Power of Veto",
+    name: "🔦 Spotlight Power of Veto",
     use: useSpotlightVeto,
 };
 
 export const BoomerangVeto: Veto = {
-    name: "Boomerang Power of Veto",
+    name: "🪃 Boomerang Power of Veto",
     use: useBoomerangVeto,
 };
 

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -23,6 +23,13 @@ export const SpotlightVeto: Veto = {
     use: useSpotlightVeto,
 };
 
+export const BoomerangVeto: Veto = {
+    name: "Boomerang Power of Veto",
+    use: () => {
+        throw new Error("Boomerang veto is not implemented yet.");
+    },
+};
+
 function useSpotlightVeto(
     hero: Houseguest,
     nominees: Houseguest[],

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -174,7 +174,10 @@ function useDiamondVeto(
 
 function basicVetoChecks(hero: Houseguest, nominees: Houseguest[], gameState: GameState, HoH: number) {
     if (hero.id === HoH) {
-        return useDiamondVeto(hero, nominees, gameState, HoH, true);
+        return {
+            decision: null,
+            reason: "These are my ideal nominations.",
+        };
     }
     for (const nom of nominees) {
         if (hero.id === nom.id) return { decision: hero, reason: "I am going to save myself." };

--- a/src/components/seasonEditor/seasonEditorList.tsx
+++ b/src/components/seasonEditor/seasonEditorList.tsx
@@ -7,7 +7,7 @@ import { BigBrotherVanilla } from "../episode/bigBrotherEpisode";
 import { BehaviorSubject, Subscription } from "rxjs";
 import { getEmoji, twist$ } from "./twistAdder";
 import { min } from "lodash";
-import { removeFirstNMatching } from "../../utils";
+import { removeFirstNMatching, removeLast1Matching } from "../../utils";
 import { EpisodeLibrary } from "../../model/season";
 
 const common = `
@@ -142,10 +142,10 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
             });
             this.refreshItems(newItems);
         } else {
-            // remove the first instance of the twist, and add X vanilla episodes
+            // remove the LAST instance of the twist, and add X vanilla episodes
             const newItems = Array.from(this.state.items);
-            removeFirstNMatching(newItems, 1, (item) => item.episode === twist.type);
-            this.refreshItems(newItems);
+            const i = removeLast1Matching(newItems, (item) => item.episode === twist.type);
+            this.refreshItems(newItems, i);
         }
     }
 
@@ -158,7 +158,7 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
         this.subs.forEach((sub) => sub.unsubscribe());
     }
 
-    private refreshItems(newItems: SeasonEditorListItem[]) {
+    private refreshItems(newItems: SeasonEditorListItem[], addIndex?: number) {
         const finalItems = [];
         let week: number = 0;
         let playerCount: number = this.props.castSize;
@@ -178,12 +178,17 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
         if (playerCount > 3) {
             while (playerCount > 3) {
                 week++;
-                finalItems.unshift({
+                const item = {
                     id: (this.id++).toString(),
                     weekText: `Week ${week}: F${playerCount}`,
                     episode: BigBrotherVanilla,
                     isValid: true,
-                });
+                };
+                if (addIndex !== undefined) {
+                    finalItems.splice(addIndex, 0, item);
+                } else {
+                    finalItems.unshift(item);
+                }
                 playerCount--;
             }
             this.refreshItems(finalItems);

--- a/src/components/seasonEditor/seasonEditorList.tsx
+++ b/src/components/seasonEditor/seasonEditorList.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import { EpisodeType } from "../episode/episodes";
 import { BigBrotherVanilla } from "../episode/bigBrotherEpisode";
 import { BehaviorSubject, Subscription } from "rxjs";
-import { twist$ } from "./twistAdder";
+import { getEmoji, twist$ } from "./twistAdder";
 import { min } from "lodash";
 import { removeFirstNMatching } from "../../utils";
 import { EpisodeLibrary } from "../../model/season";
@@ -65,7 +65,7 @@ const ListItem = ({
             {...provided.dragHandleProps}
         >
             <span>{`${item.weekText}${
-                item.episode !== BigBrotherVanilla ? ` | ${item.episode.name}` : ""
+                item.episode !== BigBrotherVanilla ? ` | ${getEmoji(item.episode) + item.episode.name}` : ""
             }`}</span>
         </Item>
     );

--- a/src/components/seasonEditor/seasonEditorList.tsx
+++ b/src/components/seasonEditor/seasonEditorList.tsx
@@ -9,7 +9,6 @@ import { twist$ } from "./twistAdder";
 import { min } from "lodash";
 import { removeFirstNMatching } from "../../utils";
 import { EpisodeLibrary } from "../../model/season";
-import { Tooltip } from "../tooltip/tooltip";
 
 const common = `
 padding: 10px;
@@ -58,7 +57,7 @@ const ListItem = ({
     snapshot: any;
 }): JSX.Element => {
     const Item = item.isValid ? DragItem : InvalidDragItem;
-    const result = (
+    return (
         <Item
             ref={provided.innerRef}
             snapshot={snapshot}
@@ -70,17 +69,11 @@ const ListItem = ({
             }`}</span>
         </Item>
     );
-    return item.isValid ? (
-        result
-    ) : (
-        <Tooltip text={`Cannot play ${item.episode.name.slice(2)} with ${item.players} players.`}>
-            {result}
-        </Tooltip>
-    );
 };
 
 interface SeasonEditorListProps {
     castSize: number;
+    setTwistsValid: (valid: boolean) => void;
 }
 
 interface SeasonEditorListState {
@@ -89,7 +82,6 @@ interface SeasonEditorListState {
 
 interface SeasonEditorListItem {
     id: string;
-    players: number;
     weekText: string;
     episode: EpisodeType;
     isValid: boolean;
@@ -113,7 +105,6 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
                 weekText: `Week ${week}: F${i}`,
                 episode: BigBrotherVanilla,
                 isValid: true,
-                players: i,
             });
         }
         _items = elements;
@@ -148,7 +139,6 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
                 weekText: ``,
                 episode: twist.type,
                 isValid: true,
-                players: -1,
             });
             this.refreshItems(newItems);
         } else {
@@ -176,9 +166,7 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
         for (const item of newItems) {
             const isValid = item.episode.canPlayWith(playerCount);
             week++;
-            item.weekText = `${isValid ? `Week ${week}: F${playerCount}` : "N/A"}`;
             item.weekText = `Week ${week}: F${playerCount}`;
-            item.players = playerCount;
             item.isValid = isValid;
             playerCount -= item.episode.eliminates;
             // delete all vanilla big brother episodes if player count is below 3
@@ -195,7 +183,6 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
                     weekText: `Week ${week}: F${playerCount}`,
                     episode: BigBrotherVanilla,
                     isValid: true,
-                    players: playerCount,
                 });
                 playerCount--;
             }
@@ -203,6 +190,7 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
         }
         _items = finalItems;
         this.setState({ items: finalItems });
+        this.props.setTwistsValid(finalItems.every((item) => item.isValid));
     }
     public render() {
         const onDragEnd = (result: any) => {

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { defaultJurySize, GameState, validateJurySize } from "../../model/gameState";
 import { cast$, newEpisode, pushToMainContentStream, season$ } from "../../subjects/subjects";
 import { NumericInput } from "../castingScreen/numericInput";
+import { BattleOfTheBlock } from "../episode/botbEpisode";
 import { BoomerangVetoEpisode } from "../episode/boomerangVetoEpisode";
 import { CoHoH } from "../episode/coHoHEpisode";
 import { DiamondVetoEpisode } from "../episode/diamondVetoEpisode";
@@ -41,6 +42,7 @@ const twists: EpisodeType[] = [
     ForcedVetoEpisode,
     BoomerangVetoEpisode,
     CoHoH,
+    BattleOfTheBlock,
 ];
 
 const submit = async (jury: number): Promise<void> => {

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -58,8 +58,8 @@ const submit = async (jury: number): Promise<void> => {
 export function SeasonEditorPage(): JSX.Element {
     const castLength = cast$.value.length;
     const [jurySize, setJurySize] = useState(`${defaultJurySize(castLength)}`);
-    const validJurySize = validateJurySize(parseInt(jurySize), castLength); // TODO: also validate the twist list
-    // TODO: probably using a usestate in here then callback and passit and bind(This) oh wait no its not cause its stastse.
+    const validJurySize = validateJurySize(parseInt(jurySize), castLength);
+    const [areTwistsValid, setTwistsValid] = useState(true);
     return (
         <div className="columns">
             <div className="column is-one-quarter">
@@ -68,7 +68,7 @@ export function SeasonEditorPage(): JSX.Element {
                 </HasText>
                 <hr />
                 <Noselect>
-                    <SeasonEditorList castSize={castLength} />
+                    <SeasonEditorList setTwistsValid={setTwistsValid} castSize={castLength} />
                 </Noselect>
             </div>
             <div className="column" style={{ padding: 20 }}>
@@ -120,7 +120,7 @@ export function SeasonEditorPage(): JSX.Element {
                     onClick={() => {
                         submit(parseInt(jurySize));
                     }}
-                    disabled={!validJurySize}
+                    disabled={!validJurySize || !areTwistsValid}
                 >
                     Submit
                 </button>

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -77,7 +77,7 @@ export function SeasonEditorPage(): JSX.Element {
                 <Subheader>Add Twists</Subheader>
                 <div className="columns is-multiline is-centered">
                     {twists.map((type) => (
-                        <TwistAdder type={type} key={type.name} />
+                        <TwistAdder type={type} key={`${type.name}${type.emoji}`} />
                     ))}
                     <div
                         className="column is-4"
@@ -115,7 +115,7 @@ export function SeasonEditorPage(): JSX.Element {
                     </div>
                 </div>
             </div>
-            <div className="column is-narrow" style={{ padding: 40 }}>
+            <div className="column is-narrow" style={{ paddingTop: 20, paddingRight: 20 }}>
                 <button
                     className="button is-success"
                     style={{ float: "right" }}

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { defaultJurySize, GameState, validateJurySize } from "../../model/gameState";
 import { cast$, newEpisode, pushToMainContentStream, season$ } from "../../subjects/subjects";
 import { NumericInput } from "../castingScreen/numericInput";
+import { BoomerangVetoEpisode } from "../episode/boomerangVetoEpisode";
 import { DiamondVetoEpisode } from "../episode/diamondVetoEpisode";
 import { DoubleEviction } from "../episode/doubleEvictionEpisode";
 import { EpisodeType } from "../episode/episodes";
@@ -29,7 +30,7 @@ export const Label = styled.label`
     color: #fff;
 `;
 
-// TODO: boomerang veto, double veto.
+// TODO: double veto.
 
 const twists: EpisodeType[] = [
     DoubleEviction,
@@ -39,6 +40,7 @@ const twists: EpisodeType[] = [
     NoVeto,
     DiamondVetoEpisode,
     ForcedVetoEpisode,
+    BoomerangVetoEpisode,
 ];
 
 const submit = async (jury: number): Promise<void> => {
@@ -56,7 +58,8 @@ const submit = async (jury: number): Promise<void> => {
 export function SeasonEditorPage(): JSX.Element {
     const castLength = cast$.value.length;
     const [jurySize, setJurySize] = useState(`${defaultJurySize(castLength)}`);
-    const validJurySize = validateJurySize(parseInt(jurySize), castLength);
+    const validJurySize = validateJurySize(parseInt(jurySize), castLength); // TODO: also validate the twist list
+    // TODO: probably using a usestate in here then callback and passit and bind(This) oh wait no its not cause its stastse.
     return (
         <div className="columns">
             <div className="column is-one-quarter">

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -30,8 +30,6 @@ export const Label = styled.label`
     color: #fff;
 `;
 
-// TODO: double veto.
-
 const twists: EpisodeType[] = [
     DoubleEviction,
     TripleEvictionCad,

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -4,6 +4,7 @@ import { defaultJurySize, GameState, validateJurySize } from "../../model/gameSt
 import { cast$, newEpisode, pushToMainContentStream, season$ } from "../../subjects/subjects";
 import { NumericInput } from "../castingScreen/numericInput";
 import { BoomerangVetoEpisode } from "../episode/boomerangVetoEpisode";
+import { CoHoH } from "../episode/coHoHEpisode";
 import { DiamondVetoEpisode } from "../episode/diamondVetoEpisode";
 import { DoubleEviction } from "../episode/doubleEvictionEpisode";
 import { EpisodeType } from "../episode/episodes";
@@ -39,6 +40,7 @@ const twists: EpisodeType[] = [
     DiamondVetoEpisode,
     ForcedVetoEpisode,
     BoomerangVetoEpisode,
+    CoHoH,
 ];
 
 const submit = async (jury: number): Promise<void> => {

--- a/src/components/seasonEditor/twistAdder.tsx
+++ b/src/components/seasonEditor/twistAdder.tsx
@@ -7,6 +7,10 @@ import { Label } from "./seasonEditorPage";
 
 export const twist$ = new Subject<{ type: EpisodeType; add: boolean }>();
 
+export function getEmoji(episode: EpisodeType): string {
+    return episode.emoji ? `${episode.emoji} ` : "";
+}
+
 interface TwistAdderProps {
     type: EpisodeType;
 }
@@ -35,7 +39,7 @@ export class TwistAdder extends React.Component<
         const twistCount = this.state.twistCount;
         return (
             <div
-                className="column is-narrow"
+                className="column is-5-desktop is-5-widescreen is-5-fullhd is-12-tablet"
                 style={{
                     border: "1px solid #808080",
                     borderRadius: "4px",
@@ -43,12 +47,12 @@ export class TwistAdder extends React.Component<
                     margin: "10px",
                 }}
             >
-                <div className="field has-addons has-addons-centered">
-                    <p
-                        className="field-label is-normal control"
-                        style={{ textAlign: "right", marginRight: "1em" }}
-                    >
-                        <Label className="label">{this.props.type.name}</Label>
+                <div className="field has-addons has-addons-centered" style={{ textAlign: "center" }}>
+                    <p className="field-label is-normal control">
+                        <Label className="label">
+                            {getEmoji(this.props.type)}
+                            {this.props.type.name}
+                        </Label>
                     </p>
                     <p className="control">
                         <button

--- a/src/components/seasonEditor/twistAdder.tsx
+++ b/src/components/seasonEditor/twistAdder.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Subject, Subscription } from "rxjs";
 import { NumericInputStyle } from "../castingScreen/numericInput";
 import { EpisodeType } from "../episode/episodes";
+import { Tooltip } from "../tooltip/tooltip";
 import { twistCapacity$ } from "./seasonEditorList";
 import { Label } from "./seasonEditorPage";
 
@@ -47,41 +48,43 @@ export class TwistAdder extends React.Component<
                     margin: "10px",
                 }}
             >
-                <div className="field has-addons has-addons-centered" style={{ textAlign: "center" }}>
-                    <p className="field-label is-normal control">
-                        <Label className="label">
-                            {getEmoji(this.props.type)}
-                            {this.props.type.name}
-                        </Label>
-                    </p>
-                    <p className="control">
-                        <button
-                            className="button is-danger"
-                            disabled={twistCount === 0}
-                            onClick={() => {
-                                twist$.next({ type: this.props.type, add: false });
-                                this.setState({ twistCount: twistCount - 1 });
-                            }}
-                        >
-                            -
-                        </button>
-                    </p>
-                    <p className="control">
-                        <NumericInputStyle className="input" readOnly value={`${twistCount}`} />
-                    </p>
-                    <p className="control">
-                        <button
-                            className="button is-success"
-                            onClick={() => {
-                                twist$.next({ type: this.props.type, add: true });
-                                this.setState({ twistCount: twistCount + 1 });
-                            }}
-                            disabled={this.state.twistCapacity < this.props.type.eliminates}
-                        >
-                            +
-                        </button>
-                    </p>
-                </div>
+                <Tooltip wide={true} text={this.props.type.description}>
+                    <div className="field has-addons has-addons-centered" style={{ textAlign: "center" }}>
+                        <p className="field-label is-normal control">
+                            <Label className="label">
+                                {getEmoji(this.props.type)}
+                                {this.props.type.name}
+                            </Label>
+                        </p>
+                        <p className="control">
+                            <button
+                                className="button is-danger"
+                                disabled={twistCount === 0}
+                                onClick={() => {
+                                    twist$.next({ type: this.props.type, add: false });
+                                    this.setState({ twistCount: twistCount - 1 });
+                                }}
+                            >
+                                -
+                            </button>
+                        </p>
+                        <p className="control">
+                            <NumericInputStyle className="input" readOnly value={`${twistCount}`} />
+                        </p>
+                        <p className="control">
+                            <button
+                                className="button is-success"
+                                onClick={() => {
+                                    twist$.next({ type: this.props.type, add: true });
+                                    this.setState({ twistCount: twistCount + 1 });
+                                }}
+                                disabled={this.state.twistCapacity < this.props.type.eliminates}
+                            >
+                                +
+                            </button>
+                        </p>
+                    </div>
+                </Tooltip>
             </div>
         );
     }

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -2,18 +2,24 @@ import React from "react";
 import Popover from "react-tiny-popover";
 import styled from "styled-components";
 
+const common = `padding: 3px 8px;
+color: #fff;
+text-align: center;
+background-color: #000;
+border-radius: 4px;`;
+
 const Text = styled.p`
     max-width: 200px;
-    padding: 3px 8px;
-    color: #fff;
-    text-align: center;
-    background-color: #000;
-    border-radius: 4px;
+    ${common}
 `;
-
+const WideText = styled.p`
+    max-width: 800px;
+    ${common}
+`;
 interface TooltipProps {
     text: string;
     children: any;
+    wide?: boolean;
 }
 
 interface ToolTipState {
@@ -27,11 +33,12 @@ export class Tooltip extends React.Component<TooltipProps, ToolTipState> {
     }
 
     public render() {
+        const Txt = this.props.wide ? WideText : Text;
         return (
             <Popover
                 position={["top", "bottom"]}
                 isOpen={this.state.visible}
-                content={<Text>{this.props.text}</Text>}
+                content={<Txt>{this.props.text}</Txt>}
             >
                 <div
                     onMouseEnter={() => this.setState({ visible: true })}

--- a/src/model/gameState.ts
+++ b/src/model/gameState.ts
@@ -88,7 +88,7 @@ export class GameState extends _GameState {
     readonly nonEvictedHouseguests: Set<number> = new Set<number>();
     readonly remainingPlayers: number = 0;
     readonly phase: number = 0;
-    readonly previousHOH?: Houseguest;
+    readonly previousHOH?: Houseguest[];
     readonly log: EpisodeLog[][] = [];
     readonly cliques: Cliques[] = [];
 
@@ -136,7 +136,7 @@ export class MutableGameState extends _GameState {
     readonly nonEvictedHouseguests: Set<number> = new Set<number>();
     public remainingPlayers: number = 0;
     public phase: number = 0;
-    public previousHOH?: Houseguest;
+    public previousHOH?: Houseguest[];
     public cliques: Cliques[] = [];
     public log: EpisodeLog[][] = [];
 

--- a/src/model/logging/voteType.tsx
+++ b/src/model/logging/voteType.tsx
@@ -8,6 +8,7 @@ import {
     NomineeCell,
     HohCell,
     SaveCell,
+    PoVCell,
 } from "../../components/episode/scenes/votingTable";
 
 let voteKey = 0;
@@ -73,6 +74,20 @@ export class NomineeVote implements VoteType {
     );
     constructor(evicted: boolean) {
         this.evicted = evicted;
+    }
+}
+
+export class PoVvote implements VoteType {
+    id: number;
+    render = (state: GameState) => {
+        return (
+            <PoVCell key={getKey()}>
+                <CenteredItallic noMargin={true}>{getById(state, this.id).name}</CenteredItallic>
+            </PoVCell>
+        );
+    };
+    constructor(id: number) {
+        this.id = id;
     }
 }
 

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -129,6 +129,7 @@ export function backdoorNPlayers(
     gameState: GameState,
     n: number
 ): NumberWithLogic[] {
+    if (options.length < n) throw new Error(`Tried to backdoor ${n} players with ${options.length} options.`);
     const result: NumberWithLogic[] = [];
     const sortedOptions = [...options];
     // negative value if first is less than second

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -122,8 +122,6 @@ function castF4vote(hero: Houseguest, nom0: Houseguest, nom1: Houseguest, HoH: H
     };
 }
 
-// only works for 2 nominees
-
 // returns the id of the houseguests you're backdooring
 export function backdoorNPlayers(
     hero: Houseguest,

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -85,7 +85,7 @@ function determineWinrateStrategy(hero: Houseguest): WinrateStrategy {
     return WinrateStrategy.Medium;
 }
 
-function determineStrategy(hero: Houseguest): TargetStrategy {
+export function determineStrategy(hero: Houseguest): TargetStrategy {
     if (hero.friends === hero.enemies) return TargetStrategy.MoR;
     return hero.friends > hero.enemies ? TargetStrategy.StatusQuo : TargetStrategy.Underdog;
 }

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -107,3 +107,18 @@ export function removeFirstNMatching(array: any[], n: number, match: (x: any) =>
     }
     return array;
 }
+
+// takes in an array, a number n, and a match function, then removes the last elements from the array for which the match function returns true
+// returns the index of the first element that does not match, or -1
+
+export function removeLast1Matching(array: any[], match: (x: any) => boolean): number {
+    let i = array.length - 1;
+    while (i >= 0) {
+        if (match(array[i])) {
+            array.splice(i, 1);
+            return i;
+        }
+        i--;
+    }
+    return -1;
+}


### PR DESCRIPTION
New Twists:
- **Boomerang Veto**: A veto that must be discarded or used to save both nominees.
- **Co-HoH**: Two HoHs each name one nominee, and are responsible for replacing the person they nominated if the veto is used on them. Neither HoH is eligible to participate in HoH next week.
- **Battle of the Block**: Two HoHs name a total of four nominees. The nominees compete in a competition, and the winners are safe for the week and dethrone the HoH who nominated them. The week then proceeds as normal.

Cast Updates:
- Removed duplicate cast "Kirby 64: The Cyrstal Shards": Duplicate of "Kirby 64: The Crystal Shards"

New Casts:
- Valorant
- Brazilian Team Mascots (contributed by @domasan12#2527)
- Big Brother Australia 14
- Pinoy Big Brother 2
- Celebrity Big Brother 1 US
- Celebrity Big Brother 2 US
- Celebrity Big Brother 3 US

Other Features:
- Emojis now appear in the week list, to help you remember what twist happened on what week.
- To make them stand out more, special vetos now show an emoji next to their name during the veto competition scene.
- Normalized the sizing on the boxes containing twist adders on the season editor page.
- Removing twists in the season editor page now removes them from the bottom instead of the top.
- Twists now have descriptions in the season editor page.

Bugfixes:
- You can no longer have the F4 round contain a forced veto.
