### PR TITLE
Split house

### DIFF
--- a/src/components/editRelationshipsScreen/editRelationshipScreen.tsx
+++ b/src/components/editRelationshipsScreen/editRelationshipScreen.tsx
@@ -182,7 +182,7 @@ export class EditRelationshipsScreen extends React.Component<
                     >
                         {this.state.swapButtonActive ? "Cancel" : "Swap"}
                     </button>
-                    {this.props.initialTribes && (
+                    {!!this.props.initialTribes?.length && (
                         <div className={`dropdown ${someoneSelected ? "is-hoverable" : ""} is-up`}>
                             <div className="dropdown-trigger">
                                 <button className="button" style={disabledStyle}>

--- a/src/components/editRelationshipsScreen/editRelationshipScreen.tsx
+++ b/src/components/editRelationshipsScreen/editRelationshipScreen.tsx
@@ -168,6 +168,7 @@ export class EditRelationshipsScreen extends React.Component<
                         className={`button is-warning`}
                         onClick={() => {
                             this.setState({ relationships: firstImpressionsMap(props.profiles.length) });
+                            selectPlayer(null);
                         }}
                     >
                         Random All

--- a/src/components/editRelationshipsScreen/editRelationshipScreen.tsx
+++ b/src/components/editRelationshipsScreen/editRelationshipScreen.tsx
@@ -161,7 +161,7 @@ export class EditRelationshipsScreen extends React.Component<
         const disabledStyle = someoneSelected ? {} : { opacity: 0.5, cursor: "not-allowed" };
         return (
             <HasText>
-                <MemoryWall houseguests={profiles} />
+                <MemoryWall splits={[{ houseguests: profiles }]} />
                 <CenteredBold>{helpText}</CenteredBold>
                 <div className="buttons is-centered">
                     <button

--- a/src/components/episode/allianceList.tsx
+++ b/src/components/episode/allianceList.tsx
@@ -24,7 +24,8 @@ export function AllianceList(props: AllianceListProps) {
     const elements: JSX.Element[] = [];
     cliques_array.forEach((cliques, j) => {
         elements.push(<hr key={`hr${j}`} />);
-        elements.push(<CenteredBold key={`title${j}`}>{props.gameState.split[j].name}</CenteredBold>);
+        props.gameState.split[j] &&
+            elements.push(<CenteredBold key={`title${j}`}>{props.gameState.split[j].name}</CenteredBold>);
         if (cliques.length === 0) {
             elements.push(
                 <HasText>

--- a/src/components/episode/allianceList.tsx
+++ b/src/components/episode/allianceList.tsx
@@ -29,38 +29,43 @@ export function AllianceList(props: AllianceListProps) {
                 </Centered>
             </HasText>
         );
-    const cliques = props.gameState.cliques;
-    const elements: JSX.Element[] = cliques.map((clique, i) => {
-        if (isNotWellDefined(clique.affiliates)) {
-            return (
+    const cliques_array = props.gameState.cliques;
+    const elements: JSX.Element[] = [];
+    cliques_array.forEach((cliques, j) => {
+        elements.push(<hr key={`hr${j}`} />);
+        cliques.forEach((clique, i) => {
+            if (isNotWellDefined(clique.affiliates)) {
+                return elements.push(
+                    <Portraits
+                        centered={true}
+                        detailed={true}
+                        key={`${i}, ${j}, ${props.gameState.phase}`}
+                        houseguests={clique.core.map((id) => getById(props.gameState, id))}
+                    />
+                );
+            }
+            const entries: (number | "⬅️" | "➡️")[] = [
+                ...clique.affiliates[0],
+                "➡️",
+                ...clique.core,
+                "⬅️",
+                ...clique.affiliates[1],
+            ];
+            elements.push(
                 <Portraits
                     centered={true}
                     detailed={true}
-                    key={`${clique}, ${i}, ${props.gameState.phase}`}
-                    houseguests={clique.core.map((id) => getById(props.gameState, id))}
+                    key={`${i}, ${j}, ${props.gameState.phase}`}
+                    houseguests={entries.map((id) => {
+                        if (id === "⬅️") return "⬅️";
+                        if (id === "➡️") return "➡️";
+                        return getById(props.gameState, id);
+                    })}
                 />
             );
-        }
-        const entries: (number | "⬅️" | "➡️")[] = [
-            ...clique.affiliates[0],
-            "➡️",
-            ...clique.core,
-            "⬅️",
-            ...clique.affiliates[1],
-        ];
-        return (
-            <Portraits
-                centered={true}
-                detailed={true}
-                key={`${clique}, ${i}, ${props.gameState.phase}`}
-                houseguests={entries.map((id) => {
-                    if (id === "⬅️") return "⬅️";
-                    if (id === "➡️") return "➡️";
-                    return getById(props.gameState, id);
-                })}
-            />
-        );
+        });
     });
+    elements.shift();
     return (
         <div>
             {elements}

--- a/src/components/episode/allianceList.tsx
+++ b/src/components/episode/allianceList.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { canDisplayCliques, GameState, getById } from "../../model";
+import { GameState, getById } from "../../model";
 import { ColorTheme } from "../../theme/theme";
 import { isNotWellDefined } from "../../utils";
 import { Centered } from "../layout/centered";
@@ -20,19 +20,20 @@ interface AllianceListProps {
 }
 
 export function AllianceList(props: AllianceListProps) {
-    if (!canDisplayCliques(props.gameState))
-        return (
-            <HasText>
-                <Centered>
-                    ⚠️ There are too many players left in the game to display the alliances! Try again when
-                    there are 30 or less! ⚠️
-                </Centered>
-            </HasText>
-        );
     const cliques_array = props.gameState.cliques;
     const elements: JSX.Element[] = [];
     cliques_array.forEach((cliques, j) => {
         elements.push(<hr key={`hr${j}`} />);
+        if (cliques.length === 0) {
+            elements.push(
+                <HasText>
+                    <Centered>
+                        ⚠️ There are too many players left in the game to display the alliances! Try again
+                        when there are 30 or less! ⚠️
+                    </Centered>
+                </HasText>
+            );
+        }
         cliques.forEach((clique, i) => {
             if (isNotWellDefined(clique.affiliates)) {
                 return elements.push(

--- a/src/components/episode/allianceList.tsx
+++ b/src/components/episode/allianceList.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { GameState, getById } from "../../model";
 import { ColorTheme } from "../../theme/theme";
 import { isNotWellDefined } from "../../utils";
-import { Centered } from "../layout/centered";
+import { Centered, CenteredBold } from "../layout/centered";
 import { HasText } from "../layout/text";
 import { Portraits } from "../playerPortrait/portraits";
 
@@ -24,6 +24,7 @@ export function AllianceList(props: AllianceListProps) {
     const elements: JSX.Element[] = [];
     cliques_array.forEach((cliques, j) => {
         elements.push(<hr key={`hr${j}`} />);
+        elements.push(<CenteredBold key={`title${j}`}>{props.gameState.split[j].name}</CenteredBold>);
         if (cliques.length === 0) {
             elements.push(
                 <HasText>
@@ -66,7 +67,7 @@ export function AllianceList(props: AllianceListProps) {
             );
         });
     });
-    elements.shift();
+    elements.shift(); // removes the leading hr
     return (
         <div>
             {elements}

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -73,7 +73,7 @@ export function defaultContent(initialGameState: GameState) {
 }
 
 export function generateBbVanilla(initialGamestate: GameState): Episode {
-    const episode = generateBBVanillaScenes(initialGamestate, GoldenVeto);
+    const episode = generateBBVanillaScenes(initialGamestate, { veto: GoldenVeto });
     return new Episode({
         scenes: episode.scenes,
         gameState: new GameState(episode.gameState),
@@ -82,10 +82,15 @@ export function generateBbVanilla(initialGamestate: GameState): Episode {
     });
 }
 
+interface BBVanillaOptions {
+    doubleEviction?: boolean;
+    veto: Veto | null;
+    splitIndex?: number;
+}
+
 export function generateBBVanillaScenes(
     initialGamestate: GameState,
-    veto: Veto | null,
-    doubleEviction: boolean = false
+    options: BBVanillaOptions
 ): {
     gameState: GameState;
     scenes: Scene[];
@@ -94,6 +99,8 @@ export function generateBBVanillaScenes(
     let currentGameState: GameState;
     let hohCompScene: Scene;
     const scenes: Scene[] = [];
+    const doubleEviction = !!options.doubleEviction;
+    const veto = options.veto;
 
     [currentGameState, hohCompScene, hohArray] = generateHohCompScene(initialGamestate, { doubleEviction });
     const hoh = hohArray[0];

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -1,11 +1,4 @@
-import {
-    GameState,
-    Houseguest,
-    EpisodeType,
-    Episode,
-    getNonEvictedHgsFromSplitIndex,
-    nonEvictedHouseguests,
-} from "../../model";
+import { GameState, Houseguest, EpisodeType, Episode, nonEvictedHousguestsSplit } from "../../model";
 import { generateHohCompScene } from "./scenes/hohCompScene";
 import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
 import { generateVetoCompScene } from "./scenes/vetoCompScene";
@@ -19,7 +12,6 @@ import styled from "styled-components";
 import { weekStartTab$ } from "../../subjects/subjects";
 import { WeekStartWrapper } from "./bigBrotherWeekstartWrapper";
 import { GoldenVeto, Veto } from "./veto/veto";
-import { isNotWellDefined } from "../../utils";
 
 export const BigBrotherVanilla: EpisodeType = {
     canPlayWith: (n: number) => {
@@ -37,11 +29,6 @@ export const BigBrotherVanilla: EpisodeType = {
 const TabItem = styled.li`
     cursor: pointer;
 `;
-
-// Refactoring ideas
-/**
- * Might be best to start passing ids instead of houseguests for HoH/nominees/veto winner
- */
 
 function Tab(props: { text: string; active: number; id: number; setActive: any }): JSX.Element {
     return (
@@ -149,9 +136,7 @@ export function generateVetoScenesOnwards(
 ) {
     let povWinner: Houseguest | undefined = undefined;
     // force no veto if 3 or less houseguests are participating in the episode
-    const lessThan3hgs = !isNotWellDefined(splitIndex)
-        ? getNonEvictedHgsFromSplitIndex(splitIndex, currentGameState).length <= 3
-        : nonEvictedHouseguests(currentGameState).length <= 3;
+    const lessThan3hgs = nonEvictedHousguestsSplit(splitIndex, currentGameState).length <= 3;
     if (veto && !lessThan3hgs) {
         let vetoCompScene;
         [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
@@ -168,9 +153,7 @@ export function generateVetoScenesOnwards(
             [hoh],
             nominees,
             povWinner,
-            doubleEviction,
-            veto,
-            immuneHgs
+            { doubleEviction, veto, immuneHgs, splitIndex }
         );
         scenes.push(vetoCeremonyScene);
     }

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -161,6 +161,7 @@ export function generateVetoScenesOnwards(
     [currentGameState, evictionScene] = generateEvictionScene(currentGameState, [hoh], nominees, {
         doubleEviction,
         votingTo: "Evict",
+        splitIndex,
     });
 
     scenes.push(evictionScene);

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -102,7 +102,10 @@ export function generateBBVanillaScenes(
     const doubleEviction = !!options.doubleEviction;
     const veto = options.veto;
 
-    [currentGameState, hohCompScene, hohArray] = generateHohCompScene(initialGamestate, { doubleEviction });
+    [currentGameState, hohCompScene, hohArray] = generateHohCompScene(initialGamestate, {
+        doubleEviction,
+        splitIndex: options.splitIndex,
+    });
     const hoh = hohArray[0];
     scenes.push(hohCompScene);
 

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -101,10 +101,11 @@ export function generateBBVanillaScenes(
     const scenes: Scene[] = [];
     const doubleEviction = !!options.doubleEviction;
     const veto = options.veto;
+    const splitIndex = options.splitIndex;
 
     [currentGameState, hohCompScene, hohArray] = generateHohCompScene(initialGamestate, {
         doubleEviction,
-        splitIndex: options.splitIndex,
+        splitIndex,
     });
     const hoh = hohArray[0];
     scenes.push(hohCompScene);
@@ -113,6 +114,7 @@ export function generateBBVanillaScenes(
     let nominees: Houseguest[];
     [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, [hoh], {
         doubleEviction,
+        splitIndex,
     });
     scenes.push(nomCeremonyScene);
 
@@ -128,6 +130,7 @@ export function generateVetoScenesOnwards(
     immuneHgs: Houseguest[]
 ) {
     let povWinner: Houseguest | undefined = undefined;
+    // TODO: force no veto if houseguests (based on split index or not) is 3 or less
     if (veto) {
         let vetoCompScene;
         [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(

--- a/src/components/episode/bigBrotherFinale.tsx
+++ b/src/components/episode/bigBrotherFinale.tsx
@@ -20,7 +20,7 @@ export function generateBbFinale(initialGameState: GameState): Episode {
     const title = "Finale";
     const content = (
         <HasText>
-            <MemoryWall houseguests={initialGameState.houseguests} /> <br />
+            <MemoryWall splits={[{ houseguests: initialGameState.houseguests }]} /> <br />
             <NextEpisodeButton />
         </HasText>
     );

--- a/src/components/episode/bigBrotherWeekstartWrapper.tsx
+++ b/src/components/episode/bigBrotherWeekstartWrapper.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GameState, getById } from "../../model";
+import { GameState, getSplitMembers } from "../../model";
 import { weekStartTab$ } from "../../subjects/subjects";
 import { Subscription } from "rxjs";
 import { MemoryWall } from "../memoryWall";
@@ -51,9 +51,7 @@ export class WeekStartWrapper extends React.Component<WeekStartWrapperProps, Wee
                     : this.props.gameState.split.map((split) => {
                           return {
                               splitName: split.name,
-                              houseguests: Array.from(split.members).map((id) =>
-                                  getById(this.props.gameState, id)
-                              ),
+                              houseguests: getSplitMembers(split, this.props.gameState),
                           };
                       });
 

--- a/src/components/episode/bigBrotherWeekstartWrapper.tsx
+++ b/src/components/episode/bigBrotherWeekstartWrapper.tsx
@@ -29,20 +29,22 @@ export class WeekStartWrapper extends React.Component<WeekStartWrapperProps, Wee
     render() {
         const helpText1 =
             this.props.gameState.phase === 1 ? (
-                <div key="helptext1" style={{ marginTop: 10 }}>
+                <div key="helptext1" style={{ marginTop: 20 }}>
                     <b>Try clicking on houseguests to view their relationships.</b> <br />
                 </div>
             ) : null;
         const helptext2 =
             this.props.gameState.phase === 2 ? (
-                <HelpLink
-                    key="helptext2"
-                    href="https://github.com/spaulmark/bb-bots/blob/master/README.md#understanding-relationships"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    What do the 🛇 ✘ ♥ 💔 🎯 symbols mean?
-                </HelpLink>
+                <div key="helptext1" style={{ marginTop: 20 }}>
+                    <HelpLink
+                        key="helptext2"
+                        href="https://github.com/spaulmark/bb-bots/blob/master/README.md#understanding-relationships"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        What do the 🛇 ✘ ♥ 💔 🎯 symbols mean?
+                    </HelpLink>
+                </div>
             ) : null;
         if (this.state.tab === 0) {
             const splits =

--- a/src/components/episode/bigBrotherWeekstartWrapper.tsx
+++ b/src/components/episode/bigBrotherWeekstartWrapper.tsx
@@ -30,7 +30,7 @@ export class WeekStartWrapper extends React.Component<WeekStartWrapperProps, Wee
         const helpText1 =
             this.props.gameState.phase === 1 ? (
                 <div key="helptext1" style={{ marginTop: 20 }}>
-                    <b>Try clicking on houseguests to view their relationships.</b> <br />
+                    <b>Try clicking on players to view their relationships.</b> <br />
                 </div>
             ) : null;
         const helptext2 =

--- a/src/components/episode/bigBrotherWeekstartWrapper.tsx
+++ b/src/components/episode/bigBrotherWeekstartWrapper.tsx
@@ -50,7 +50,7 @@ export class WeekStartWrapper extends React.Component<WeekStartWrapperProps, Wee
                     ? [{ houseguests: this.props.gameState.houseguests }]
                     : this.props.gameState.split.map((split) => {
                           return {
-                              name: split.name,
+                              splitName: split.name,
                               houseguests: Array.from(split.members).map((id) =>
                                   getById(this.props.gameState, id)
                               ),

--- a/src/components/episode/bigBrotherWeekstartWrapper.tsx
+++ b/src/components/episode/bigBrotherWeekstartWrapper.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GameState } from "../../model";
+import { GameState, getById } from "../../model";
 import { weekStartTab$ } from "../../subjects/subjects";
 import { Subscription } from "rxjs";
 import { MemoryWall } from "../memoryWall";
@@ -45,11 +45,19 @@ export class WeekStartWrapper extends React.Component<WeekStartWrapperProps, Wee
                 </HelpLink>
             ) : null;
         if (this.state.tab === 0) {
-            return [
-                <MemoryWall key="memorywall" houseguests={this.props.gameState.houseguests} />,
-                helpText1,
-                helptext2,
-            ];
+            const splits =
+                this.props.gameState.split.length === 0
+                    ? [{ houseguests: this.props.gameState.houseguests }]
+                    : this.props.gameState.split.map((split) => {
+                          return {
+                              name: split.name,
+                              houseguests: Array.from(split.members).map((id) =>
+                                  getById(this.props.gameState, id)
+                              ),
+                          };
+                      });
+
+            return [<MemoryWall key="memorywall" splits={splits} />, helpText1, helptext2];
         }
         return <AllianceList gameState={this.props.gameState} />;
     }

--- a/src/components/episode/boomerangVetoEpisode.tsx
+++ b/src/components/episode/boomerangVetoEpisode.tsx
@@ -15,7 +15,7 @@ export const BoomerangVetoEpisode: EpisodeType = {
 };
 
 function generate(initialGamestate: GameState): Episode {
-    const episode = generateBBVanillaScenes(initialGamestate, BoomerangVeto);
+    const episode = generateBBVanillaScenes(initialGamestate, { veto: BoomerangVeto });
     return new Episode({
         gameState: new GameState(episode.gameState),
         initialGamestate,

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -59,7 +59,8 @@ function generateBoB(initialGamestate: GameState): Episode {
         finalnoms,
         false,
         scenes,
-        botbWinners
+        botbWinners,
+        undefined
     );
     currentGameState = vetostuff.gameState;
 

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -56,9 +56,7 @@ function generateCoHoH(initialGamestate: GameState): Episode {
         hohArray,
         nominees,
         povWinner,
-        false,
-        GoldenVeto,
-        []
+        { veto: GoldenVeto }
     );
     scenes.push(vetoCeremonyScene);
 

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -45,7 +45,7 @@ function generateCoHoH(initialGamestate: GameState): Episode {
         currentGameState,
         hohArray,
         nominees,
-        GoldenVeto
+        { veto: GoldenVeto }
     );
     scenes.push(vetoCompScene);
     // veto replacement scene might be different because each hoh nominated one person, so whoever gets vetoed, that hoh replaces

--- a/src/components/episode/diamondVetoEpisode.tsx
+++ b/src/components/episode/diamondVetoEpisode.tsx
@@ -15,7 +15,7 @@ export const DiamondVetoEpisode: EpisodeType = {
 };
 
 function generate(initialGamestate: GameState): Episode {
-    const episode = generateBBVanillaScenes(initialGamestate, DiamondVeto);
+    const episode = generateBBVanillaScenes(initialGamestate, { veto: DiamondVeto });
     return new Episode({
         gameState: new GameState(episode.gameState),
         initialGamestate,

--- a/src/components/episode/doubleEvictionEpisode.tsx
+++ b/src/components/episode/doubleEvictionEpisode.tsx
@@ -22,7 +22,10 @@ function generateDoubleEviction(initialGamestate: GameState): Episode {
     const scenes: Scene[] = [];
 
     currentGameState.incrementLogIndex();
-    const doubleEviction = generateBBVanillaScenes(currentGameState, GoldenVeto, true);
+    const doubleEviction = generateBBVanillaScenes(currentGameState, {
+        veto: GoldenVeto,
+        doubleEviction: true,
+    });
     currentGameState = doubleEviction.gameState;
     scenes.push(
         new Scene({

--- a/src/components/episode/episodeFactory.ts
+++ b/src/components/episode/episodeFactory.ts
@@ -61,6 +61,7 @@ export function nextEpisode(oldState: GameState, episodeType: EpisodeType): Epis
     if (oldState.remainingPlayers > 2 && !episodeType.pseudo) {
         newState.log[newState.phase] = [new EpisodeLog()];
     }
+    !episodeType.pseudo && (newState.currentLog.weekEmoji = episodeType.emoji || "");
     const split: Split[] = episodeType.splitFunction ? episodeType.splitFunction(newState) : [];
     newState.split = split;
     refreshHgStats(newState, split, true);

--- a/src/components/episode/episodeFactory.ts
+++ b/src/components/episode/episodeFactory.ts
@@ -66,8 +66,7 @@ export function nextEpisode(oldState: GameState, episodeType: EpisodeType): Epis
         newState.log[newState.phase] = [new EpisodeLog()];
     }
     const split: Split[] = episodeType.splitFunction ? episodeType.splitFunction(newState) : [];
-
-    // TODO: this needs to take into account a house split
+    newState.split = split;
     refreshHgStats(newState, split, true);
     nonEvictedHouseguests(newState).forEach((hg) => {
         hg.previousPopularity = hg.popularity;

--- a/src/components/episode/episodeFactory.ts
+++ b/src/components/episode/episodeFactory.ts
@@ -7,10 +7,6 @@ import { generateCliques } from "../../utils/generateCliques";
 import { refreshHgStats } from "./utilities/evictHouseguest";
 import { cast$ } from "../../subjects/subjects";
 
-export function canDisplayCliques(newState: GameState): boolean {
-    return newState.remainingPlayers <= 30;
-}
-
 export function firstImpressionsMap(hgs: number): { [id: number]: { [id: number]: number } } {
     const sin = Math.sin;
     const cos = Math.cos;
@@ -71,7 +67,7 @@ export function nextEpisode(oldState: GameState, episodeType: EpisodeType): Epis
     nonEvictedHouseguests(newState).forEach((hg) => {
         hg.previousPopularity = hg.popularity;
     });
-    if (canDisplayCliques(newState)) newState.cliques = generateCliques(newState);
+    newState.cliques = generateCliques(newState);
     const finalState = new GameState(newState);
     if (!episodeType.canPlayWith(finalState.remainingPlayers))
         throw new Error(

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -47,6 +47,10 @@ export interface Split {
     members: Set<number>;
 }
 
+export function getMembersFromSplitIndex(index: number, gameState: GameState): Houseguest[] {
+    return getSplitMembers(gameState.split[index], gameState);
+}
+
 export function getSplitMembers(split: { members: Set<number> }, gameState: GameState): Houseguest[] {
     return Array.from(split.members).map((id) => getById(gameState, id));
 }

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -47,6 +47,10 @@ export interface Split {
     members: Set<number>;
 }
 
+export function getNonEvictedHgsFromSplitIndex(index: number, gameState: GameState): Houseguest[] {
+    return getMembersFromSplitIndex(index, gameState).filter((hg) => !hg.isEvicted);
+}
+
 export function getMembersFromSplitIndex(index: number, gameState: GameState): Houseguest[] {
     return getSplitMembers(gameState.split[index], gameState);
 }

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -41,6 +41,11 @@ export class Episode {
     }
 }
 
+export interface Split {
+    name: string;
+    members: Set<number>;
+}
+
 export interface EpisodeType {
     readonly canPlayWith: (n: number) => boolean;
     readonly eliminates: number;
@@ -52,5 +57,6 @@ export interface EpisodeType {
     readonly emoji?: string;
     readonly description?: string;
     readonly teamsLookupId?: number;
+    readonly splitFunction?: (gameState: GameState) => Split[];
     readonly generate: (gameState: GameState) => Episode;
 }

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { GameState, getById } from "../../model/gameState";
+import { GameState, getById, nonEvictedHouseguests } from "../../model/gameState";
 import { Scene } from "./scenes/scene";
 import { ViewsBar } from "../viewsBar/viewBar";
 import { defaultContent } from "./bigBrotherEpisode";
 import { getEmoji } from "../seasonEditor/twistAdder";
 import { Houseguest } from "../../model";
+import { isNotWellDefined } from "../../utils";
 
 export interface InitEpisode {
     scenes: Scene[];
@@ -47,7 +48,13 @@ export interface Split {
     members: Set<number>;
 }
 
-export function getNonEvictedHgsFromSplitIndex(index: number, gameState: GameState): Houseguest[] {
+export function nonEvictedHousguestsSplit(splitIndex: number | null | undefined, gameState: GameState) {
+    return isNotWellDefined(splitIndex)
+        ? nonEvictedHouseguests(gameState)
+        : getNonEvictedHgsFromSplitIndex(splitIndex, gameState);
+}
+
+function getNonEvictedHgsFromSplitIndex(index: number, gameState: GameState): Houseguest[] {
     return getMembersFromSplitIndex(index, gameState).filter((hg) => !hg.isEvicted);
 }
 

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { GameState } from "../../model/gameState";
+import { GameState, getById } from "../../model/gameState";
 import { Scene } from "./scenes/scene";
 import { ViewsBar } from "../viewsBar/viewBar";
 import { defaultContent } from "./bigBrotherEpisode";
 import { getEmoji } from "../seasonEditor/twistAdder";
+import { Houseguest } from "../../model";
 
 export interface InitEpisode {
     scenes: Scene[];
@@ -44,6 +45,10 @@ export class Episode {
 export interface Split {
     name: string;
     members: Set<number>;
+}
+
+export function getSplitMembers(split: { members: Set<number> }, gameState: GameState): Houseguest[] {
+    return Array.from(split.members).map((id) => getById(gameState, id));
 }
 
 export interface EpisodeType {

--- a/src/components/episode/forcedVetoEpisode.tsx
+++ b/src/components/episode/forcedVetoEpisode.tsx
@@ -15,7 +15,7 @@ export const ForcedVetoEpisode: EpisodeType = {
 };
 
 function generateForcedVeto(initialGamestate: GameState): Episode {
-    const episode = generateBBVanillaScenes(initialGamestate, SpotlightVeto);
+    const episode = generateBBVanillaScenes(initialGamestate, { veto: SpotlightVeto });
     return new Episode({
         gameState: new GameState(episode.gameState),
         initialGamestate,

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -21,7 +21,7 @@ function generateInstantEviction(initialGamestate: GameState): Episode {
     const scenes: Scene[] = [];
 
     currentGameState.incrementLogIndex();
-    const doubleEviction = generateBBVanillaScenes(currentGameState, null, true);
+    const doubleEviction = generateBBVanillaScenes(currentGameState, { veto: null, doubleEviction: true });
     currentGameState = doubleEviction.gameState;
 
     scenes.push(

--- a/src/components/episode/noVetoEpisode.tsx
+++ b/src/components/episode/noVetoEpisode.tsx
@@ -14,7 +14,7 @@ export const NoVeto: EpisodeType = {
 };
 
 function generateNoVeto(initialGamestate: GameState): Episode {
-    const episode = generateBBVanillaScenes(initialGamestate, null);
+    const episode = generateBBVanillaScenes(initialGamestate, { veto: null });
     return new Episode({
         gameState: new GameState(episode.gameState),
         initialGamestate,

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -1,4 +1,4 @@
-import { GameState, Houseguest, MutableGameState, nonEvictedHouseguests, getById } from "../../../model";
+import { GameState, Houseguest, MutableGameState, getById, nonEvictedHousguestsSplit } from "../../../model";
 import { Scene } from "./scene";
 import { shuffle } from "lodash";
 import { ProfileHouseguest } from "../../memoryWall";
@@ -33,6 +33,7 @@ interface EvictionSceneOptions {
     votingTo: "Save" | "Evict";
     doubleEviction?: boolean;
     tieBreaker?: TieBreaker;
+    splitIndex?: number;
 }
 
 export function generateEvictionScene(
@@ -52,7 +53,7 @@ export function generateEvictionScene(
     let outOf = 0;
     const nonVoters = new Set<number>(nominees.map((hg) => hg.id));
     hohArray.forEach((h) => nonVoters.add(h.id));
-    nonEvictedHouseguests(newGameState).forEach((hg) => {
+    nonEvictedHousguestsSplit(options.splitIndex, newGameState).forEach((hg) => {
         if (!nonVoters.has(hg.id)) {
             const logic = castVote(hg, nominees, newGameState);
             const result: ProfileHouseguest = { ...hg };
@@ -88,7 +89,7 @@ export function generateEvictionScene(
             : new HoHVote(tiebreakerDecision);
     }
     let evictees: Houseguest[] = [];
-
+    const zeroZeroTie = tieBreaker.decision > -1 && voteCounts[pluralities[tieBreaker.decision]] === 0;
     if (options.votingTo === "Evict") {
         // voting to evict
         if (tieBreaker.decision > -1) {
@@ -157,17 +158,19 @@ export function generateEvictionScene(
         gameState: initialGameState,
         content: (
             <div style={margin}>
-                <CenteredBold>{voteCountText}</CenteredBold>
-                <div className="columns is-centered">
-                    {votes.map((voters, i) => (
-                        <DividerBox className="column" key={`voters${i}`}>
-                            <Portraits houseguests={voters} centered={true} />
-                        </DividerBox>
-                    ))}
-                </div>
+                {!zeroZeroTie && <CenteredBold>{voteCountText}</CenteredBold>}
+                {!zeroZeroTie && (
+                    <div className="columns is-centered">
+                        {votes.map((voters, i) => (
+                            <DividerBox className="column" key={`voters${i}`}>
+                                <Portraits houseguests={voters} centered={true} />
+                            </DividerBox>
+                        ))}
+                    </div>
+                )}
                 {tieVote && (
                     <div>
-                        <CenteredBold> We have a tie.</CenteredBold>
+                        {!zeroZeroTie && <CenteredBold> We have a tie.</CenteredBold>}
                         <Centered>{soleVoteText}</Centered>
                         <Portraits houseguests={[displayHoH]} centered={true} />
                         <CenteredBold>

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -176,7 +176,14 @@ export function generateEvictionScene(
                         </CenteredBold>
                     </div>
                 )}
-                <Portraits houseguests={nominees.map((hg) => getById(newGameState, hg.id))} centered={true} />
+                <Portraits
+                    houseguests={nominees.map((_hg) => {
+                        const hg: ProfileHouseguest = { ...getById(initialGameState, _hg.id) };
+                        if (evicteesSet.has(_hg.id)) hg.isEvicted = true;
+                        return hg;
+                    })}
+                    centered={true}
+                />
                 {options.votingTo === "Save" && (
                     <CenteredBold>{`${listNames(
                         nominees.filter((nom) => !evicteesSet.has(nom.id)).map((hg) => hg.name)

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -72,6 +72,9 @@ export function generateEvictionScene(
     newGameState.currentLog.outOf = outOf;
     if (outOf === 1) {
         newGameState.currentLog.soleVoter = lastVoter!!.name;
+    } else if (outOf === 0) {
+        // special case when there are only 3 hgs left and the hoh is the only one who can vote
+        newGameState.currentLog.soleVoter = hohArray[0].name;
     }
     let tieVote = pluralities.length > 1;
     let tieBreaker = { decision: -1, reason: "" };

--- a/src/components/episode/scenes/hohCompScene.tsx
+++ b/src/components/episode/scenes/hohCompScene.tsx
@@ -1,4 +1,11 @@
-import { exclude, GameState, Houseguest, MutableGameState, randomPlayer } from "../../../model";
+import {
+    exclude,
+    GameState,
+    getMembersFromSplitIndex,
+    Houseguest,
+    MutableGameState,
+    randomPlayer,
+} from "../../../model";
 import { Scene } from "./scene";
 import { Portrait, Portraits } from "../../playerPortrait/portraits";
 import { NextEpisodeButton } from "../../nextEpisodeButton/nextEpisodeButton";
@@ -6,6 +13,7 @@ import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
 import { HoHVote } from "../../../model/logging/voteType";
 import { listNames } from "../../../utils/listStrings";
+import { isNotWellDefined } from "../../../utils";
 
 interface HohCompOptions {
     doubleEviction?: boolean;
@@ -16,6 +24,7 @@ interface HohCompOptions {
     compName?: string;
     bottomText?: string;
     competitors?: Houseguest[];
+    splitIndex?: number;
 }
 
 export function generateHohCompScene(
@@ -23,11 +32,14 @@ export function generateHohCompScene(
     options: HohCompOptions
 ): [GameState, Scene, Houseguest[]] {
     const newGameState = new MutableGameState(initialGameState);
+    const houseguests = isNotWellDefined(options.splitIndex)
+        ? newGameState.houseguests
+        : getMembersFromSplitIndex(options.splitIndex, newGameState);
     const coHoH = options.coHoH || false;
     const coHohIsFinal = options.coHohIsFinal || false;
     const doubleEviction: boolean = options.doubleEviction || false;
     const previousHoh = initialGameState.previousHOH ? initialGameState.previousHOH : [];
-    const competitors = options.competitors || exclude(newGameState.houseguests, previousHoh);
+    const competitors = options.competitors || exclude(houseguests, previousHoh);
     const newHoH: Houseguest = randomPlayer(competitors);
     const newHoH2: Houseguest = options.coHoH ? randomPlayer(competitors, [newHoH, ...previousHoh]) : newHoH;
     // set previous hoh

--- a/src/components/episode/scenes/hohCompScene.tsx
+++ b/src/components/episode/scenes/hohCompScene.tsx
@@ -76,7 +76,7 @@ export function generateHohCompScene(
                     (doubleEviction ? (
                         <CenteredBold>
                             Houseguests, please return to the living room. Tonight will be a{" "}
-                            {initialGameState.__logindex__ === 1 ? "double" : "triple"} eviction.
+                            {initialGameState.__logindex__ > 1 ? "another double" : "double"} eviction.
                         </CenteredBold>
                     ) : (
                         <Centered>

--- a/src/components/episode/scenes/vetoCompScene.tsx
+++ b/src/components/episode/scenes/vetoCompScene.tsx
@@ -2,11 +2,10 @@ import {
     GameState,
     Houseguest,
     MutableGameState,
-    nonEvictedHouseguests,
     randomPlayer,
     getById,
     exclude,
-    getNonEvictedHgsFromSplitIndex,
+    nonEvictedHousguestsSplit,
 } from "../../../model";
 import { Scene } from "./scene";
 import { Portraits } from "../../playerPortrait/portraits";
@@ -15,7 +14,6 @@ import React from "react";
 import { Centered, CenteredBold } from "../../layout/centered";
 import { listNames } from "../../../utils/listStrings";
 import { Veto } from "../veto/veto";
-import { isNotWellDefined } from "../../../utils";
 
 interface VetoCompSceneOptions {
     veto: Veto;
@@ -33,9 +31,7 @@ export function generateVetoCompScene(
     const veto = options.veto;
     const doubleEviction = !!options.doubleEviction;
     const splitIndex = options.splitIndex;
-    const nonEvictedHgs = isNotWellDefined(splitIndex)
-        ? nonEvictedHouseguests(newGameState)
-        : getNonEvictedHgsFromSplitIndex(splitIndex, newGameState);
+    const nonEvictedHgs = nonEvictedHousguestsSplit(splitIndex, newGameState);
 
     const hohPlaysVeto = newGameState.hohPlaysVeto || newGameState.remainingPlayers <= 5 || HoHs.length > 1;
     const maxVetoPlayers = hohPlaysVeto ? 6 : 5;

--- a/src/components/episode/splitHouse.tsx
+++ b/src/components/episode/splitHouse.tsx
@@ -32,11 +32,11 @@ function generate(initialGamestate: GameState): Episode {
     currentGameState.previousHOH = _.cloneDeep(initialGamestate.previousHOH) || [];
     split0.scenes.forEach((scene) => scenes.push(scene));
     nonEvictedHousguestsSplit(1, currentGameState).forEach((hg) => {
-        currentGameState.currentLog.votes[hg.id] = new GrayVote("Not Eligible");
+        currentGameState.currentLog.votes[hg.id] = new BlankVote();
     });
     currentGameState.incrementLogIndex();
     nonEvictedHousguestsSplit(0, currentGameState).forEach((hg) => {
-        currentGameState.currentLog.votes[hg.id] = new GrayVote("Not Eligible");
+        currentGameState.currentLog.votes[hg.id] = new BlankVote();
     });
     const split1 = generateBBVanillaScenes(currentGameState, {
         veto: GoldenVeto,

--- a/src/components/episode/splitHouse.tsx
+++ b/src/components/episode/splitHouse.tsx
@@ -5,7 +5,7 @@ import { Scene } from "./scenes/scene";
 import { GoldenVeto } from "./veto/veto";
 import { shuffle } from "lodash";
 import _ from "lodash";
-import { BlankVote, GrayVote } from "../../model/logging/voteType";
+import { BlankVote } from "../../model/logging/voteType";
 
 export const SplitHouse: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,

--- a/src/components/episode/splitHouse.tsx
+++ b/src/components/episode/splitHouse.tsx
@@ -1,0 +1,58 @@
+import { GameState, MutableGameState } from "../../model";
+import { generateBBVanillaScenes } from "./bigBrotherEpisode";
+import { Episode, EpisodeType, Split } from "./episodes";
+import React from "react";
+import { Scene } from "./scenes/scene";
+import { GoldenVeto } from "./veto/veto";
+import { shuffle } from "lodash";
+
+export const SplitHouse: EpisodeType = {
+    canPlayWith: (n: number) => n >= 6,
+    eliminates: 2,
+    arrowsEnabled: true,
+    emoji: "↔️",
+    hasViewsbar: true,
+    name: "Split House",
+    description:
+        "Houseguests are divided into two groups, and each group plays a round of Big Brother, isolated from the others.",
+    splitFunction: splitHouseRandomly(["Indoors", "Outdoors"]),
+    generate,
+};
+
+// TODO: the split needs to get assigned to the gamestate in the episode factory
+function generate(initialGamestate: GameState): Episode {
+    let currentGameState = new MutableGameState(initialGamestate);
+    const scenes: Scene[] = [];
+    // currentGameState.incrementLogIndex();
+    const doubleEviction = generateBBVanillaScenes(currentGameState, GoldenVeto, true);
+    currentGameState = doubleEviction.gameState;
+    scenes.push(
+        new Scene({
+            title: "Double Eviction",
+            content: <div>{doubleEviction.scenes.map((scene) => scene.content)}</div>,
+            gameState: doubleEviction.gameState,
+        })
+    );
+
+    return new Episode({
+        gameState: new GameState(currentGameState),
+        initialGamestate,
+        scenes,
+        type: SplitHouse,
+    });
+}
+
+function splitHouseRandomly(names: string[]): (gameState: GameState) => Split[] {
+    return (currentGameState: GameState) => {
+        const nonEvictedHouseguests: number[] = shuffle(Array.from(currentGameState.nonEvictedHouseguests));
+        const members: Set<number>[] = Array(names.length).fill(new Set<number>());
+        nonEvictedHouseguests.forEach((hgid, i) => {
+            members[i % names.length].add(hgid);
+        });
+        const result: Split[] = members.map((members, i) => ({
+            name: names[i],
+            members,
+        }));
+        return result;
+    };
+}

--- a/src/components/episode/splitHouse.tsx
+++ b/src/components/episode/splitHouse.tsx
@@ -24,7 +24,10 @@ function generate(initialGamestate: GameState): Episode {
     let currentGameState = new MutableGameState(initialGamestate);
     const scenes: Scene[] = [];
     // currentGameState.incrementLogIndex();
-    const doubleEviction = generateBBVanillaScenes(currentGameState, GoldenVeto, true);
+    const doubleEviction = generateBBVanillaScenes(currentGameState, {
+        doubleEviction: true,
+        veto: GoldenVeto,
+    });
     currentGameState = doubleEviction.gameState;
     scenes.push(
         new Scene({

--- a/src/components/episode/splitHouse.tsx
+++ b/src/components/episode/splitHouse.tsx
@@ -1,10 +1,11 @@
 import { GameState, MutableGameState } from "../../model";
 import { generateBBVanillaScenes } from "./bigBrotherEpisode";
-import { Episode, EpisodeType, Split } from "./episodes";
+import { Episode, EpisodeType, nonEvictedHousguestsSplit, Split } from "./episodes";
 import { Scene } from "./scenes/scene";
 import { GoldenVeto } from "./veto/veto";
 import { shuffle } from "lodash";
 import _ from "lodash";
+import { BlankVote, GrayVote } from "../../model/logging/voteType";
 
 export const SplitHouse: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
@@ -30,8 +31,13 @@ function generate(initialGamestate: GameState): Episode {
     const split0prevHoH = _.cloneDeep(split0.gameState.previousHOH);
     currentGameState.previousHOH = _.cloneDeep(initialGamestate.previousHOH) || [];
     split0.scenes.forEach((scene) => scenes.push(scene));
-    // TODO: i think the HGs not in the current split need [blank votes] //
+    nonEvictedHousguestsSplit(1, currentGameState).forEach((hg) => {
+        currentGameState.currentLog.votes[hg.id] = new GrayVote("Not Eligible");
+    });
     currentGameState.incrementLogIndex();
+    nonEvictedHousguestsSplit(0, currentGameState).forEach((hg) => {
+        currentGameState.currentLog.votes[hg.id] = new GrayVote("Not Eligible");
+    });
     const split1 = generateBBVanillaScenes(currentGameState, {
         veto: GoldenVeto,
         splitIndex: 1,

--- a/src/components/episode/splitHouse.tsx
+++ b/src/components/episode/splitHouse.tsx
@@ -45,7 +45,10 @@ function generate(initialGamestate: GameState): Episode {
 function splitHouseRandomly(names: string[]): (gameState: GameState) => Split[] {
     return (currentGameState: GameState) => {
         const nonEvictedHouseguests: number[] = shuffle(Array.from(currentGameState.nonEvictedHouseguests));
-        const members: Set<number>[] = Array(names.length).fill(new Set<number>());
+        const members: Set<number>[] = [];
+        for (let i = 0; i < names.length; i++) {
+            members.push(new Set<number>());
+        }
         nonEvictedHouseguests.forEach((hgid, i) => {
             members[i % names.length].add(hgid);
         });

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -61,9 +61,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
         [hoh],
         nominees,
         povWinner,
-        doubleEviction,
-        GoldenVeto,
-        []
+        { doubleEviction, veto: GoldenVeto }
     );
     tripleScenes.push(vetoCeremonyScene);
 

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -24,6 +24,7 @@ export const TripleEvictionCad: EpisodeType = {
 export function generateTripleEvictionCad(initialGamestate: GameState): Episode {
     let currentGameState = new MutableGameState(initialGamestate);
     const scenes: Scene[] = [];
+    const doubleEviction = true;
 
     currentGameState.incrementLogIndex();
 
@@ -31,7 +32,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
     let hohCompScene: Scene;
     const tripleScenes: Scene[] = [];
     [currentGameState, hohCompScene, hohArray] = generateHohCompScene(currentGameState, {
-        doubleEviction: true,
+        doubleEviction,
         customText: "Houseguests, please return to the living room. Tonight will be a triple eviction.",
     });
     tripleScenes.push(hohCompScene);
@@ -40,20 +41,17 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
     let nomCeremonyScene;
     let nominees: Houseguest[];
     [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, [hoh], {
-        doubleEviction: true,
+        doubleEviction,
         thirdNominee: true,
     });
     tripleScenes.push(nomCeremonyScene);
 
     let vetoCompScene;
     let povWinner: Houseguest;
-    [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(
-        currentGameState,
-        [hoh],
-        nominees,
-        GoldenVeto,
-        true
-    );
+    [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(currentGameState, [hoh], nominees, {
+        veto: GoldenVeto,
+        doubleEviction,
+    });
     tripleScenes.push(vetoCompScene);
 
     let vetoCeremonyScene;
@@ -63,7 +61,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
         [hoh],
         nominees,
         povWinner,
-        true,
+        doubleEviction,
         GoldenVeto,
         []
     );
@@ -71,7 +69,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
 
     let evictionScene;
     [currentGameState, evictionScene] = generateEvictionScene(currentGameState, [hoh], nominees, {
-        doubleEviction: true,
+        doubleEviction,
         votingTo: "Save",
     });
     tripleScenes.push(evictionScene);

--- a/src/components/episode/utilities/evictHouseguest.ts
+++ b/src/components/episode/utilities/evictHouseguest.ts
@@ -105,10 +105,10 @@ function updateFriendCounts(houseguests: Houseguest[], gameState: GameState) {
         hero.enemies = enemies;
         if (houseguests.length < 3) return;
         // this stuff breaks if there are less than 3 players left
-        targets.refreshTargets(gameState);
+        targets.refreshTargets(gameState, houseguests);
         hero.targets = targets.getTargets();
         hero.targets.forEach((target) => {
-            getById(gameState, target).targetingMe++;
+            target >= 0 && getById(gameState, target).targetingMe++;
         });
     });
 }

--- a/src/components/episode/utilities/evictHouseguest.ts
+++ b/src/components/episode/utilities/evictHouseguest.ts
@@ -8,6 +8,7 @@ import {
     getJurors,
     inJury,
     MutableGameState,
+    getSplitMembers,
 } from "../../../model";
 import { getFinalists } from "../../../model/season";
 import { average, roundTwoDigits } from "../../../utils";
@@ -24,8 +25,7 @@ export function evictHouseguest(gameState: MutableGameState, id: number): GameSt
     }
     gameState.nonEvictedHouseguests.delete(evictee.id);
     gameState.remainingPlayers--;
-    refreshHgStats(gameState, []); // TODO: pass in the split from the gamestate
-    // ^^ this might break with double evictions and chainables, b/c the split house ends after the round...? idk; leave it for now //
+    refreshHgStats(gameState, gameState.split);
     return gameState;
 }
 
@@ -46,7 +46,7 @@ export function refreshHgStats(
             ? split
             : [{ members: new Set<number>(nonEvictedHouseguests(gameState).map((hg) => hg.id)) }];
     splits.forEach((split) => {
-        const hgs = Array.from(split.members).map((id) => getById(gameState, id));
+        const hgs = getSplitMembers(split, gameState);
         updatePopularity(hgs, updateDelta);
         updateFriendCounts(hgs, gameState);
     });

--- a/src/components/episode/utilities/evictHouseguest.ts
+++ b/src/components/episode/utilities/evictHouseguest.ts
@@ -41,9 +41,6 @@ export function refreshHgStats(
     if (inJury(gameState)) {
         updatePowerRankings(nonEvictedHouseguests(gameState));
     }
-    // TODO: both of these things need updating, make it so it takes in a list of ids instead of reading from the gamestate
-
-    //  //
     const splits =
         split.length > 0
             ? split

--- a/src/components/memoryWall/memoryWall.tsx
+++ b/src/components/memoryWall/memoryWall.tsx
@@ -3,6 +3,7 @@ import { PlayerProfile } from "../../model";
 import { Portraits } from "../playerPortrait/portraits";
 import { RelationshipMap } from "../../utils";
 import { Tribe } from "../../model/tribe";
+import { TribeContainer } from "./tribeContainer";
 export interface MemoryWallProps {
     readonly splits: { splitName?: string; houseguests: ProfileHouseguest[] }[];
 }
@@ -28,14 +29,11 @@ export interface ProfileHouseguest extends PlayerProfile {
 export function MemoryWall(props: MemoryWallProps): JSX.Element {
     const result: JSX.Element[] = [];
     let key = 0;
-    for (const split of props.splits) {
-        const houseguests = split.houseguests;
-        if (!houseguests || houseguests.length === 0) {
-            result.push(<div key={key++} />);
-            continue;
-        }
-        result.push(<hr key={key++} />);
-        result.push(
+
+    if (props.splits.length === 1) {
+        const houseguests = props.splits[0].houseguests;
+        if (houseguests.length === 0) return <div key={key++} />;
+        return (
             <div
                 key={key++}
                 style={{
@@ -47,6 +45,35 @@ export function MemoryWall(props: MemoryWallProps): JSX.Element {
             </div>
         );
     }
-    result.shift();
-    return <div>{result}</div>;
+
+    // FIXME: split color doesn't exist yet //
+    for (const split of props.splits) {
+        const houseguests = split.houseguests;
+        result.push(
+            <div
+                key={key++}
+                style={{
+                    margin: "auto",
+                    maxWidth: houseguests.length < 26 ? 800 : -1,
+                }}
+            >
+                <TribeContainer
+                    hgs={houseguests}
+                    key={key++}
+                    tribe={{ name: split.splitName || "", color: "#fff" }}
+                />
+            </div>
+        );
+    }
+    return (
+        <div
+            style={{
+                margin: "auto",
+                maxWidth: -1,
+            }}
+        >
+            {/* // FIXME: this used to say is-multiline. it likely breaks for more than 2 splits */}
+            <div className="columns is-centered">{result}</div>
+        </div>
+    );
 }

--- a/src/components/memoryWall/memoryWall.tsx
+++ b/src/components/memoryWall/memoryWall.tsx
@@ -4,7 +4,7 @@ import { Portraits } from "../playerPortrait/portraits";
 import { RelationshipMap } from "../../utils";
 import { Tribe } from "../../model/tribe";
 export interface MemoryWallProps {
-    readonly houseguests: ProfileHouseguest[];
+    readonly splits: { splitName?: string; houseguests: ProfileHouseguest[] }[];
 }
 
 export interface ProfileHouseguest extends PlayerProfile {
@@ -25,19 +25,25 @@ export interface ProfileHouseguest extends PlayerProfile {
     editable?: boolean;
     ignoreSelected?: boolean;
 }
-
 export function MemoryWall(props: MemoryWallProps): JSX.Element {
-    if (!props.houseguests || props.houseguests.length === 0) {
-        return <div />;
+    const result: JSX.Element[] = [];
+    let key = 0;
+    for (const split of props.splits) {
+        const houseguests = split.houseguests;
+        if (!houseguests || houseguests.length === 0) {
+            result.push(<div key={key++} />);
+        }
+        result.push(
+            <div
+                key={key++}
+                style={{
+                    margin: "auto",
+                    maxWidth: houseguests.length < 26 ? 800 : -1,
+                }}
+            >
+                <Portraits houseguests={houseguests} centered={true} detailed={true} />
+            </div>
+        );
     }
-    return (
-        <div
-            style={{
-                margin: "auto",
-                maxWidth: props.houseguests.length < 26 ? 800 : -1,
-            }}
-        >
-            <Portraits houseguests={props.houseguests} centered={true} detailed={true} />
-        </div>
-    );
+    return <div>{result}</div>;
 }

--- a/src/components/memoryWall/memoryWall.tsx
+++ b/src/components/memoryWall/memoryWall.tsx
@@ -32,7 +32,9 @@ export function MemoryWall(props: MemoryWallProps): JSX.Element {
         const houseguests = split.houseguests;
         if (!houseguests || houseguests.length === 0) {
             result.push(<div key={key++} />);
+            continue;
         }
+        result.push(<hr key={key++} />);
         result.push(
             <div
                 key={key++}
@@ -41,10 +43,10 @@ export function MemoryWall(props: MemoryWallProps): JSX.Element {
                     maxWidth: houseguests.length < 26 ? 800 : -1,
                 }}
             >
-                {split.splitName && <h2 style={{ textAlign: "center" }}>{split.splitName}</h2>}
                 <Portraits houseguests={houseguests} centered={true} detailed={true} />
             </div>
         );
     }
+    result.shift();
     return <div>{result}</div>;
 }

--- a/src/components/memoryWall/memoryWall.tsx
+++ b/src/components/memoryWall/memoryWall.tsx
@@ -41,6 +41,7 @@ export function MemoryWall(props: MemoryWallProps): JSX.Element {
                     maxWidth: houseguests.length < 26 ? 800 : -1,
                 }}
             >
+                {split.splitName && <h2 style={{ textAlign: "center" }}>{split.splitName}</h2>}
                 <Portraits houseguests={houseguests} centered={true} detailed={true} />
             </div>
         );

--- a/src/components/memoryWall/tribeContainer.tsx
+++ b/src/components/memoryWall/tribeContainer.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { DividerBox } from "../layout/box";
+import { Centered } from "../layout/centered";
+import { Portraits } from "../playerPortrait/portraits";
+import { ProfileHouseguest } from "./memoryWall";
+
+interface TribeContainerProps {
+    hgs: ProfileHouseguest[];
+    tribe: { name: string; color: string };
+}
+
+export class TribeContainer extends React.Component<TribeContainerProps, {}> {
+    public constructor(props: TribeContainerProps) {
+        super(props);
+    }
+
+    public render() {
+        // FIXME: note that tribe text does not appear in the specified color yet.
+        const tribeName = this.props.tribe.name;
+        return (
+            <DividerBox
+                className={`column ${this.props.hgs.length === 1 ? "is-narrow" : ""}`}
+                key={tribeName}
+                style={{ textAlign: "center", padding: 0 }}
+            >
+                {tribeName !== "undefined" && (
+                    <Centered>
+                        <b>{tribeName}</b>
+                    </Centered>
+                )}
+                <div
+                    style={{
+                        margin: "auto",
+                        maxWidth: this.props.hgs.length > 7 ? 800 : -1,
+                    }}
+                >
+                    <Portraits houseguests={this.props.hgs} centered={true}></Portraits>
+                </div>
+            </DividerBox>
+        );
+    }
+}

--- a/src/components/pregameScreen/pregameScreen.tsx
+++ b/src/components/pregameScreen/pregameScreen.tsx
@@ -83,7 +83,7 @@ export class PregameScreen extends React.Component<PregameScreenProps, PregameSc
                     </TopbarLink>{" "}
                     and watch as everyone votes each other out until one winner remains!
                 </Centered>
-                {props.cast.length === 0 ? "" : <MemoryWall houseguests={profiles} />}
+                {props.cast.length === 0 ? "" : <MemoryWall splits={[{ houseguests: profiles }]} />}
                 {props.cast.length === 0 ? (
                     ""
                 ) : (

--- a/src/components/seasonEditor/getEpisodeLibrary.tsx
+++ b/src/components/seasonEditor/getEpisodeLibrary.tsx
@@ -148,6 +148,7 @@ export function getEpisodeLibrary(): EpisodeLibrary {
         }
         mappedItems.splice(i, 0, { episode: endTeamsEpisodeType });
     });
+    //////////// all the crap above this is just for teams. /////////////
 
     let previousItem: EpisodeType | undefined = undefined;
     for (const item of mappedItems) {
@@ -161,6 +162,7 @@ export function getEpisodeLibrary(): EpisodeLibrary {
             const pseudoItem = previousItem;
             const newItem = item.episode;
             const common = {
+                splitFunction: newItem.splitFunction,
                 canPlayWith: () => true,
                 eliminates: pseudoItem.eliminates + newItem.eliminates,
                 emoji: `${pseudoItem.emoji} ${newItem.emoji}`,
@@ -195,6 +197,7 @@ export function getEpisodeLibrary(): EpisodeLibrary {
             const dynamicEpisodeType = {
                 arrowsEnabled: oldEpisode.arrowsEnabled || newEpisode.arrowsEnabled,
                 canPlayWith: () => true,
+                splitFunction: oldEpisode.splitFunction,
                 eliminates: oldEpisode.eliminates + newEpisode.eliminates,
                 hasViewsbar: oldEpisode.hasViewsbar || newEpisode.hasViewsbar,
                 emoji: `${oldEpisode.emoji} ${newEpisode.emoji}`,

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -74,7 +74,7 @@ function getInitialTribes(): Tribe[] {
     return tribes;
 }
 
-const submit = async (jury: number): Promise<void> => {
+const submit = async (jury: number, hohPlaysVeto: boolean): Promise<void> => {
     lastJurySize = jury;
 
     const initialTribes = getInitialTribes();
@@ -89,7 +89,7 @@ const submit = async (jury: number): Promise<void> => {
     // vscode says the awaits are unnessecary here,
     // but if you remove them then bad things happen
     await newEpisode(null);
-    await newEpisode(new PregameEpisode(new GameState({ players: getCast(), jury })));
+    await newEpisode(new PregameEpisode(new GameState({ players: getCast(), jury, hohPlaysVeto })));
 };
 
 export function SeasonEditorPage(): JSX.Element {
@@ -97,6 +97,7 @@ export function SeasonEditorPage(): JSX.Element {
     const [jurySize, setJurySize] = useState(`${defaultJurySize(castLength)}`);
     const validJurySize = validateJurySize(parseInt(jurySize), castLength);
     const [areTwistsValid, setTwistsValid] = useState(true);
+    const [hohPlaysVeto, setHohPlaysVeto] = useState(true);
     return (
         <div className="columns">
             <div className="column is-one-quarter">
@@ -115,7 +116,29 @@ export function SeasonEditorPage(): JSX.Element {
                         <TwistAdder type={type} key={`${type.name}${type.emoji}`} />
                     ))}
                     <div
-                        className="column is-4"
+                        className="column is-5-desktop is-5-widescreen is-5-fullhd is-12-tablet"
+                        style={{
+                            border: "1px solid #808080",
+                            borderRadius: "4px",
+                            backgroundColor: "#444346",
+                            margin: "10px",
+                        }}
+                    >
+                        <div className="field has-addons has-addons-centered" style={{ textAlign: "center" }}>
+                            <p className="field-label is-normal control">
+                                <Label className="label"> HoH Plays Veto?</Label>
+                            </p>
+                            <p className="control">
+                                <input
+                                    type="checkbox"
+                                    checked={hohPlaysVeto}
+                                    onChange={() => setHohPlaysVeto(!hohPlaysVeto)}
+                                />
+                            </p>
+                        </div>
+                    </div>
+                    <div
+                        className="column is-5-desktop is-5-widescreen is-5-fullhd is-12-tablet"
                         style={{
                             border: "1px solid #808080",
                             borderRadius: "4px",
@@ -157,7 +180,7 @@ export function SeasonEditorPage(): JSX.Element {
                     className="button is-success"
                     style={{ float: "right" }}
                     onClick={() => {
-                        submit(parseInt(jurySize));
+                        submit(parseInt(jurySize), hohPlaysVeto);
                     }}
                     disabled={!validJurySize || !areTwistsValid}
                 >

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -25,6 +25,7 @@ import { TwistAdder } from "./twistAdder";
 import { SafetyChain } from "../episode/safetyChain";
 import { getTeamsListContents, TeamsAdderList } from "./teamsAdderList";
 import { Tribe } from "../../model/tribe";
+import { SplitHouse } from "../episode/splitHouse";
 
 const Subheader = styled.h3`
     text-align: center;
@@ -46,6 +47,7 @@ const twists: EpisodeType[] = [
     BoomerangVetoEpisode,
     CoHoH,
     BattleOfTheBlock,
+    SplitHouse,
 ];
 
 let lastJurySize = defaultJurySize(16);

--- a/src/components/votingTable/votingTable.tsx
+++ b/src/components/votingTable/votingTable.tsx
@@ -397,7 +397,9 @@ function generateTopRow(
     }
     cells.push(
         <GrayCell key={`toprow--${week}`} colSpan={colspan}>
-            <CenteredBold noMargin={true}>Week {week}</CenteredBold>
+            <CenteredBold noMargin={true}>{`Week ${week}${
+                log.weekEmoji ? ` ${log.weekEmoji}` : ""
+            }`}</CenteredBold>
         </GrayCell>
     );
 }

--- a/src/components/votingTable/votingTable.tsx
+++ b/src/components/votingTable/votingTable.tsx
@@ -15,6 +15,20 @@ export const EndgameTableCell = styled(PaddedCell)`
     border: 1px solid ${({ theme }: { theme: ColorTheme }) => theme.tableCellBorder};
 `;
 
+export const HatchedCell = styled(EndgameTableCell)`
+    background-image: linear-gradient(
+        145deg,
+        #363537 25%,
+        #2e2e2e 25%,
+        #2e2e2e 50%,
+        #363537 50%,
+        #363537 75%,
+        #2e2e2e 75%,
+        #2e2e2e 100%
+    );
+    background-size: 69.74px 48.83px;
+`;
+
 const EndgameTable = styled.table`
     border: 1px solid ${({ theme }: { theme: ColorTheme }) => theme.tableCellBorder};
     border-collapse: collapse;

--- a/src/model/gameState.ts
+++ b/src/model/gameState.ts
@@ -64,6 +64,7 @@ export function validateJurySize(j: number, castSize: number): boolean {
 class _GameState {
     private jurors: number = 0;
     readonly houseguests: Houseguest[] = [];
+    public hohPlaysVeto: boolean = true;
 
     public finalJurySize() {
         return this.jurors;
@@ -79,6 +80,7 @@ class _GameState {
 interface InitGameState {
     players: PlayerProfile[];
     jury: number;
+    hohPlaysVeto?: boolean;
 }
 
 export class GameState extends _GameState {
@@ -124,6 +126,7 @@ export class GameState extends _GameState {
                 this.houseguests.push(hg);
             });
             this.jurySize = _init.jury;
+            this.hohPlaysVeto = _init.hohPlaysVeto === false ? false : true;
         }
         if (!this.finalJurySize()) {
             this.jurySize = defaultJurySize(this.houseguests.length);

--- a/src/model/gameState.ts
+++ b/src/model/gameState.ts
@@ -5,6 +5,7 @@ import { newRelationshipMap, rng } from "../utils";
 import { getFinalists } from "./season";
 import { EpisodeLog } from "./logging/episodelog";
 import { Cliques } from "../utils/generateCliques";
+import { Split } from "../components/episode/episodes";
 
 export function getById(gameState: GameState, id: number): Houseguest {
     return gameState.houseguestCache[id];
@@ -65,6 +66,7 @@ class _GameState {
     private jurors: number = 0;
     readonly houseguests: Houseguest[] = [];
     public hohPlaysVeto: boolean = true;
+    public split: Split[] = [];
 
     public finalJurySize() {
         return this.jurors;
@@ -81,6 +83,7 @@ interface InitGameState {
     players: PlayerProfile[];
     jury: number;
     hohPlaysVeto?: boolean;
+    split?: Split[];
 }
 
 export class GameState extends _GameState {

--- a/src/model/gameState.ts
+++ b/src/model/gameState.ts
@@ -95,7 +95,7 @@ export class GameState extends _GameState {
     readonly phase: number = 0;
     readonly previousHOH?: Houseguest[];
     readonly log: EpisodeLog[][] = [];
-    readonly cliques: Cliques[] = [];
+    readonly cliques: Cliques[][] = [];
 
     public __logindex__: number = 0;
     get currentLog(): EpisodeLog {
@@ -143,7 +143,7 @@ export class MutableGameState extends _GameState {
     public remainingPlayers: number = 0;
     public phase: number = 0;
     public previousHOH?: Houseguest[];
-    public cliques: Cliques[] = [];
+    public cliques: Cliques[][] = [];
     public log: EpisodeLog[][] = [];
 
     public __logindex__: number = 0;

--- a/src/model/logging/episodelog.ts
+++ b/src/model/logging/episodelog.ts
@@ -15,6 +15,7 @@ export class EpisodeLog {
     public votingTo?: string;
     public pseudo?: boolean = false;
     public vetoEmoji?: string;
+    public weekEmoji?: string;
     public strikethroughNominees: string[] = [];
 }
 

--- a/src/model/logging/voteType.tsx
+++ b/src/model/logging/voteType.tsx
@@ -50,6 +50,15 @@ export class NormalVote implements VoteType {
     }
 }
 
+export class BlankVote implements VoteType {
+    id: number = 0; // unused
+    render = (_: GameState) => (
+        <EndgameTableCell key={getKey()}>
+            <Centered noMargin={true} />
+        </EndgameTableCell>
+    );
+}
+
 export class WinnerVote implements VoteType {
     id: number = 1; // unused
     render = (state: GameState) => (
@@ -105,8 +114,8 @@ export class GrayVote implements VoteType {
             </NotEligibleCell>
         );
     };
-    constructor(text: string) {
-        this.text = text;
+    constructor(text?: string) {
+        this.text = text || "";
     }
 }
 

--- a/src/model/logging/voteType.tsx
+++ b/src/model/logging/voteType.tsx
@@ -11,6 +11,7 @@ import {
     PoVCell,
     NotEligibleCell,
     PaddedCell,
+    HatchedCell,
 } from "../../components/votingTable/votingTable";
 
 let voteKey = 0;
@@ -53,9 +54,9 @@ export class NormalVote implements VoteType {
 export class BlankVote implements VoteType {
     id: number = 0; // unused
     render = (_: GameState) => (
-        <EndgameTableCell key={getKey()}>
+        <HatchedCell key={getKey()}>
             <Centered noMargin={true} />
-        </EndgameTableCell>
+        </HatchedCell>
     );
 }
 

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -51,16 +51,10 @@ export class Targets {
     public getTargets(): [number, number] {
         return [this.firstTarget.id, this.secondTarget.id];
     }
-    public refreshTargets(gameState: GameState) {
-        const choices = backdoorNPlayers(
-            this.hg,
-            exclude(
-                Array.from(gameState.nonEvictedHouseguests).map((id) => getById(gameState, id)),
-                [this.hg]
-            ),
-            gameState,
-            2
-        );
+    public refreshTargets(gameState: GameState, houseguests: Houseguest[]) {
+        const exclusion = exclude(houseguests, [this.hg]);
+        if (exclusion.length < 2) return;
+        const choices = backdoorNPlayers(this.hg, exclusion, gameState, 2);
         this.firstTarget = getRelationshipSummary(this.hg, getById(gameState, choices[0].decision));
         this.secondTarget = getRelationshipSummary(this.hg, getById(gameState, choices[1].decision));
     }

--- a/src/utils/generateCliques.ts
+++ b/src/utils/generateCliques.ts
@@ -22,16 +22,17 @@ export function generateCliques(gameState: GameState): Cliques[][] {
     const result: Cliques[][] = [];
     if (gameState.split.length === 0)
         return [
-            generateCliquesBySplit(gameState, generateGraph(gameState, nonEvictedHouseguests(gameState))),
+            generateCliquesFromGraph(gameState, generateGraph(gameState, nonEvictedHouseguests(gameState))),
         ];
     gameState.split.forEach((split) => {
         const g = generateGraph(gameState, getSplitMembers(split, gameState));
-        result.push(generateCliquesBySplit(gameState, g));
+        result.push(generateCliquesFromGraph(gameState, g));
     });
     return result;
 }
 
-function generateCliquesBySplit(gameState: GameState, g: Graph): Cliques[] {
+function generateCliquesFromGraph(gameState: GameState, g: Graph | null): Cliques[] {
+    if (!g) return [];
     cliques = [];
     bronKerbosch(new Set<number>([]), new Set(g.nodes), new Set<number>([]), g);
     cliques.forEach((clique) => clique.map((id) => getById(gameState, id)));

--- a/src/utils/generateCliques.ts
+++ b/src/utils/generateCliques.ts
@@ -1,5 +1,5 @@
 import { intersection } from ".";
-import { GameState, getById } from "../model";
+import { GameState, getById, getSplitMembers, nonEvictedHouseguests } from "../model";
 import generateGraph from "./generateGraph";
 import { difference } from "./utilities";
 
@@ -18,8 +18,20 @@ export interface Cliques {
     affiliates?: [number[], number[]];
 }
 
-export function generateCliques(gameState: GameState): Cliques[] {
-    const g = generateGraph(gameState);
+export function generateCliques(gameState: GameState): Cliques[][] {
+    const result: Cliques[][] = [];
+    if (gameState.split.length === 0)
+        return [
+            generateCliquesBySplit(gameState, generateGraph(gameState, nonEvictedHouseguests(gameState))),
+        ];
+    gameState.split.forEach((split) => {
+        const g = generateGraph(gameState, getSplitMembers(split, gameState));
+        result.push(generateCliquesBySplit(gameState, g));
+    });
+    return result;
+}
+
+function generateCliquesBySplit(gameState: GameState, g: Graph): Cliques[] {
     cliques = [];
     bronKerbosch(new Set<number>([]), new Set(g.nodes), new Set<number>([]), g);
     cliques.forEach((clique) => clique.map((id) => getById(gameState, id)));

--- a/src/utils/generateGraph.ts
+++ b/src/utils/generateGraph.ts
@@ -1,4 +1,4 @@
-import { Houseguest, GameState, nonEvictedHouseguests, getById } from "../model";
+import { Houseguest, GameState, getById } from "../model";
 
 import { classifyRelationship, RelationshipType } from "./ai/classifyRelationship";
 
@@ -29,10 +29,9 @@ function generateEdge(
     return [null, 0];
 }
 
-export default function generateGraph(gameState: GameState): Graph {
+export default function generateGraph(gameState: GameState, players: Houseguest[]): Graph {
     // this algorithm assumes every relationship is mutual,
     // and will need a face lift if we get non-mutual relationships.
-    const players = nonEvictedHouseguests(gameState);
     const nodes: number[] = [];
     const edges: EdgeMap = new EdgeMap();
     players.forEach((player) => {

--- a/src/utils/generateGraph.ts
+++ b/src/utils/generateGraph.ts
@@ -29,7 +29,8 @@ function generateEdge(
     return [null, 0];
 }
 
-export default function generateGraph(gameState: GameState, players: Houseguest[]): Graph {
+export default function generateGraph(gameState: GameState, players: Houseguest[]): Graph | null {
+    if (players.length > 30) return null;
     // this algorithm assumes every relationship is mutual,
     // and will need a face lift if we get non-mutual relationships.
     const nodes: number[] = [];

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -65,7 +65,7 @@ export function isNotWellDefined(x: any): x is null | undefined {
     return x === null || x === undefined;
 }
 
-export function dot(x: number[], y: number[]) {
+function dot(x: number[], y: number[]) {
     if (x.length !== y.length)
         throw new Error(
             `Tried to get the dot product between two vectors of non-equal length: ${x.length} !== ${y.length}`
@@ -80,7 +80,7 @@ export function dot(x: number[], y: number[]) {
 export function magnitude(x: number[]): number {
     let result = 0;
     x.forEach((x) => (result += x ** 2));
-    return result;
+    return Math.sqrt(result);
 }
 
 // returns a value between 0 and pi


### PR DESCRIPTION
__New Features:__

- Split House Twist: Houseguests are divided into two groups, and each group plays a round of Big Brother, isolated from the others.
- You can now choose whether or not the HoH plays in the veto. (HoH always plays in veto from F5 onwards, per BBCAN rules)
- Emojis representing the twists that happened that week now appear in the voting table next to the title of the week.

__New Casts:__

- Zanki Zero
- Goddess of Victory: NIKKE

__Cast Updates:__

- Mahjong Soul
- Uma Musume (updated by @Derpfinity#4687)
- Danganronpa Another has been split into Danganronpa Another and Danganronpa Another 2

__Bugfixes:__

- Fixed a bug where pressing the random all button on the edit relationships screen while selecting a player could lead to inaccurate relationship data being displayed.
- Fixed a bug where surviving nominees would display with next week's data in eviction scenes.
- Fixed a bug where the Change Teams selector could appear when there were no teams.
- Fixed an inconsistency where double evictions could be incorrectly referred to as triple evictions ingame.
