### PR TITLE
Big Brother Australia

### DIFF
--- a/src/components/editRelationshipsScreen/editRelationshipScreen.tsx
+++ b/src/components/editRelationshipsScreen/editRelationshipScreen.tsx
@@ -16,7 +16,7 @@ import { PregameScreen } from "../pregameScreen/pregameScreen";
 import { Screens } from "../topbar/topBar";
 import { PregameEpisode } from "../episode/pregameEpisode";
 import { selectPlayer } from "../playerPortrait/selectedPortrait";
-import { getLastJurySize } from "../seasonEditor/seasonEditorPage";
+import { getLastHoHPlaysVeto, getLastJurySize } from "../seasonEditor/seasonEditorPage";
 import { Subject, Subscription } from "rxjs";
 import { isWellDefined } from "../../utils";
 import { shuffle } from "lodash";
@@ -215,7 +215,11 @@ export class EditRelationshipsScreen extends React.Component<
                             await newEpisode(null);
                             await newEpisode(
                                 new PregameEpisode(
-                                    new GameState({ players: getCast(), jury: getLastJurySize() })
+                                    new GameState({
+                                        players: getCast(),
+                                        jury: getLastJurySize(),
+                                        hohPlaysVeto: getLastHoHPlaysVeto(),
+                                    })
                                 )
                             );
                             pushToMainContentStream(

--- a/src/components/episode/australiaEpisode.tsx
+++ b/src/components/episode/australiaEpisode.tsx
@@ -1,0 +1,28 @@
+import { GameState } from "../../model";
+import { generateBBVanillaScenes } from "./bigBrotherEpisode";
+import { EpisodeType, Episode } from "./episodes";
+
+export const BbAustralia: EpisodeType = {
+    canPlayWith: (n: number) => n >= 4,
+    eliminates: 1,
+    arrowsEnabled: true,
+    emoji: "🇦🇺",
+    hasViewsbar: true,
+    name: "BB Australia",
+    description: "3 nominees, and no veto. Nominees are able to vote.",
+    generate,
+};
+
+function generate(initialGamestate: GameState): Episode {
+    const episode = generateBBVanillaScenes(initialGamestate, {
+        veto: null,
+        thirdNominee: true,
+        nomineesCanVote: true,
+    });
+    return new Episode({
+        gameState: new GameState(episode.gameState),
+        initialGamestate,
+        scenes: episode.scenes,
+        type: BbAustralia,
+    });
+}

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -81,6 +81,8 @@ interface BBVanillaOptions {
     doubleEviction?: boolean;
     veto: Veto | null;
     splitIndex?: number;
+    nomineesCanVote?: boolean;
+    thirdNominee?: boolean;
 }
 
 export function generateBBVanillaScenes(
@@ -95,7 +97,6 @@ export function generateBBVanillaScenes(
     let hohCompScene: Scene;
     const scenes: Scene[] = [];
     const doubleEviction = !!options.doubleEviction;
-    const veto = options.veto;
     const splitIndex = options.splitIndex;
 
     [currentGameState, hohCompScene, hohArray] = generateHohCompScene(initialGamestate, {
@@ -110,30 +111,23 @@ export function generateBBVanillaScenes(
     [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, [hoh], {
         doubleEviction,
         splitIndex,
+        thirdNominee: options.thirdNominee,
     });
     scenes.push(nomCeremonyScene);
 
-    return generateVetoScenesOnwards(
-        veto,
-        currentGameState,
-        hoh,
-        nominees,
-        doubleEviction,
-        scenes,
-        [],
-        splitIndex
-    );
+    return generateVetoScenesOnwards(currentGameState, hoh, nominees, scenes, [], options);
 }
 export function generateVetoScenesOnwards(
-    veto: Veto | null,
     currentGameState: GameState,
     hoh: Houseguest,
     nominees: Houseguest[],
-    doubleEviction: boolean,
     scenes: Scene[],
     immuneHgs: Houseguest[],
-    splitIndex: number | undefined
+    options: BBVanillaOptions
 ) {
+    const splitIndex: number | undefined = options.splitIndex;
+    const veto: Veto | null = options.veto;
+    const doubleEviction: boolean = !!options.doubleEviction;
     let povWinner: Houseguest | undefined = undefined;
     // force no veto if 3 or less houseguests are participating in the episode
     const lessThan3hgs = nonEvictedHousguestsSplit(splitIndex, currentGameState).length <= 3;
@@ -162,6 +156,7 @@ export function generateVetoScenesOnwards(
         doubleEviction,
         votingTo: "Evict",
         splitIndex,
+        nomineesCanVote: options.nomineesCanVote,
     });
 
     scenes.push(evictionScene);

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -52,16 +52,9 @@ function generateBoB(initialGamestate: GameState): Episode {
     scenes.push(botbscene);
     // then veto onwards plays normally except
     // the winning pair is somehow immune for the week: they can't be backdoored.
-    const vetostuff = generateVetoScenesOnwards(
-        GoldenVeto,
-        currentGameState,
-        finalhoh,
-        finalnoms,
-        false,
-        scenes,
-        botbWinners,
-        undefined
-    );
+    const vetostuff = generateVetoScenesOnwards(currentGameState, finalhoh, finalnoms, scenes, botbWinners, {
+        veto: GoldenVeto,
+    });
     currentGameState = vetostuff.gameState;
 
     return new Episode({

--- a/src/components/episode/episodeFactory.ts
+++ b/src/components/episode/episodeFactory.ts
@@ -6,7 +6,6 @@ import { EpisodeLog } from "../../model/logging/episodelog";
 import { generateCliques } from "../../utils/generateCliques";
 import { refreshHgStats } from "./utilities/evictHouseguest";
 import { cast$ } from "../../subjects/subjects";
-import { generateHitList } from "../../utils/ai/hitList";
 
 export function firstImpressionsMap(hgs: number): { [id: number]: { [id: number]: number } } {
     const sin = Math.sin;
@@ -71,9 +70,7 @@ export function nextEpisode(oldState: GameState, episodeType: EpisodeType): Epis
     });
     newState.cliques = generateCliques(newState);
     const finalState = new GameState(newState);
-    nonEvictedHouseguests(finalState).forEach((hg) => {
-        console.log(hg.name, generateHitList(hg, finalState)); // TODO: delete this
-    });
+
     if (!episodeType.canPlayWith(finalState.remainingPlayers))
         throw new Error(
             `Episode type ${episodeType.name} not playable with ${finalState.remainingPlayers} players`

--- a/src/components/episode/episodeFactory.ts
+++ b/src/components/episode/episodeFactory.ts
@@ -6,6 +6,8 @@ import { EpisodeLog } from "../../model/logging/episodelog";
 import { generateCliques } from "../../utils/generateCliques";
 import { refreshHgStats } from "./utilities/evictHouseguest";
 import { cast$ } from "../../subjects/subjects";
+import { RelationshipType, classifyRelationshipHgs } from "../../utils/ai/classifyRelationship";
+import { computeEnemyCentrality, computeNonfriendCentrality } from "../../utils/ai/targets";
 
 export function firstImpressionsMap(hgs: number): { [id: number]: { [id: number]: number } } {
     const sin = Math.sin;
@@ -70,9 +72,98 @@ export function nextEpisode(oldState: GameState, episodeType: EpisodeType): Epis
     });
     newState.cliques = generateCliques(newState);
     const finalState = new GameState(newState);
+    nonEvictedHouseguests(finalState).forEach((hg) => {
+        console.log(hg.name, generateHitList(hg, finalState));
+    });
     if (!episodeType.canPlayWith(finalState.remainingPlayers))
         throw new Error(
             `Episode type ${episodeType.name} not playable with ${finalState.remainingPlayers} players`
         );
     return episodeType.generate(finalState);
+}
+
+// TODO: move tihs somewhere else
+
+function generateHitList(hero: Houseguest, gameState: GameState) {
+    const list: [number, number, string][] = [];
+    const s = (a: any, b: any) => a[1] - b[1];
+
+    // now do High / MoR
+    if (hero.friends === hero.enemies) return generateHitList_high_MoR(list, hero, gameState).sort(s);
+    if (hero.friends < hero.enemies) return generateHitList_high_underdog(list, hero, gameState).sort(s);
+    return generateHitList_high_statusquo(list, hero, gameState).sort(s);
+}
+
+function generateHitList_high_underdog(
+    hitList: [number, number, string][],
+    hero: Houseguest,
+    gameState: GameState
+) {
+    for (const villian of nonEvictedHouseguests(gameState)) {
+        if (hero.id === villian.id) continue;
+        if (classifyRelationshipHgs(hero, villian) !== RelationshipType.Friend) {
+            pushEnemyCentrailty(hitList, villian, hero, gameState, computeNonfriendCentrality);
+        } else {
+            pushRelationship(hitList, villian, hero);
+        }
+    }
+    return hitList;
+}
+
+// enemies are sorted by centrailty, non-enemies are normal
+function generateHitList_high_MoR(
+    hitList: [number, number, string][],
+    hero: Houseguest,
+    gameState: GameState
+) {
+    for (const villian of nonEvictedHouseguests(gameState)) {
+        if (hero.id === villian.id) continue;
+        if (classifyRelationshipHgs(hero, villian) === RelationshipType.Enemy) {
+            pushEnemyCentrailty(hitList, villian, hero, gameState, computeEnemyCentrality);
+        } else {
+            pushRelationship(hitList, villian, hero);
+        }
+    }
+    return hitList;
+}
+
+function generateHitList_high_statusquo(
+    hitList: [number, number, string][],
+    hero: Houseguest,
+    gameState: GameState
+) {
+    for (const villian of nonEvictedHouseguests(gameState)) {
+        if (hero.id === villian.id) continue;
+        pushRelationship(hitList, villian, hero);
+    }
+    return hitList;
+}
+
+function pushEnemyCentrailty(
+    hitList: [number, number, string][],
+    villian: Houseguest,
+    hero: Houseguest,
+    gameState: GameState,
+    compareFcn: (gameState: GameState, hero: Houseguest, villian: Houseguest) => number
+) {
+    const enemyCap = hero.popularity;
+    // we flip it to make it negative, since its something we as hero dislike
+    const centrailty = -compareFcn(gameState, hero, villian);
+    // do a linear transform on centrailty to have it be from -1 to enemyCap instead of from -1 to 1 /
+    const centrailtyTransformed = linear_transform(centrailty, -1, 1, -1, enemyCap);
+    hitList.push([villian.id, centrailtyTransformed, villian.name]);
+}
+
+function linear_transform(
+    x: number,
+    input_start: number,
+    input_end: number,
+    output_start: number,
+    output_end: number
+) {
+    return ((x - input_start) / (input_end - input_start)) * (output_end - output_start) + output_start;
+}
+
+function pushRelationship(hitList: [number, number, string][], villian: Houseguest, hero: Houseguest) {
+    hitList.push([villian.id, hero.relationshipWith(villian), villian.name]);
 }

--- a/src/components/episode/episodeFactory.ts
+++ b/src/components/episode/episodeFactory.ts
@@ -6,8 +6,7 @@ import { EpisodeLog } from "../../model/logging/episodelog";
 import { generateCliques } from "../../utils/generateCliques";
 import { refreshHgStats } from "./utilities/evictHouseguest";
 import { cast$ } from "../../subjects/subjects";
-import { RelationshipType, classifyRelationshipHgs } from "../../utils/ai/classifyRelationship";
-import { computeEnemyCentrality, computeNonfriendCentrality } from "../../utils/ai/targets";
+import { generateHitList } from "../../utils/ai/hitList";
 
 export function firstImpressionsMap(hgs: number): { [id: number]: { [id: number]: number } } {
     const sin = Math.sin;
@@ -73,97 +72,11 @@ export function nextEpisode(oldState: GameState, episodeType: EpisodeType): Epis
     newState.cliques = generateCliques(newState);
     const finalState = new GameState(newState);
     nonEvictedHouseguests(finalState).forEach((hg) => {
-        console.log(hg.name, generateHitList(hg, finalState));
+        console.log(hg.name, generateHitList(hg, finalState)); // TODO: delete this
     });
     if (!episodeType.canPlayWith(finalState.remainingPlayers))
         throw new Error(
             `Episode type ${episodeType.name} not playable with ${finalState.remainingPlayers} players`
         );
     return episodeType.generate(finalState);
-}
-
-// TODO: move tihs somewhere else
-
-function generateHitList(hero: Houseguest, gameState: GameState) {
-    const list: [number, number, string][] = [];
-    const s = (a: any, b: any) => a[1] - b[1];
-
-    // now do High / MoR
-    if (hero.friends === hero.enemies) return generateHitList_high_MoR(list, hero, gameState).sort(s);
-    if (hero.friends < hero.enemies) return generateHitList_high_underdog(list, hero, gameState).sort(s);
-    return generateHitList_high_statusquo(list, hero, gameState).sort(s);
-}
-
-function generateHitList_high_underdog(
-    hitList: [number, number, string][],
-    hero: Houseguest,
-    gameState: GameState
-) {
-    for (const villian of nonEvictedHouseguests(gameState)) {
-        if (hero.id === villian.id) continue;
-        if (classifyRelationshipHgs(hero, villian) !== RelationshipType.Friend) {
-            pushEnemyCentrailty(hitList, villian, hero, gameState, computeNonfriendCentrality);
-        } else {
-            pushRelationship(hitList, villian, hero);
-        }
-    }
-    return hitList;
-}
-
-// enemies are sorted by centrailty, non-enemies are normal
-function generateHitList_high_MoR(
-    hitList: [number, number, string][],
-    hero: Houseguest,
-    gameState: GameState
-) {
-    for (const villian of nonEvictedHouseguests(gameState)) {
-        if (hero.id === villian.id) continue;
-        if (classifyRelationshipHgs(hero, villian) === RelationshipType.Enemy) {
-            pushEnemyCentrailty(hitList, villian, hero, gameState, computeEnemyCentrality);
-        } else {
-            pushRelationship(hitList, villian, hero);
-        }
-    }
-    return hitList;
-}
-
-function generateHitList_high_statusquo(
-    hitList: [number, number, string][],
-    hero: Houseguest,
-    gameState: GameState
-) {
-    for (const villian of nonEvictedHouseguests(gameState)) {
-        if (hero.id === villian.id) continue;
-        pushRelationship(hitList, villian, hero);
-    }
-    return hitList;
-}
-
-function pushEnemyCentrailty(
-    hitList: [number, number, string][],
-    villian: Houseguest,
-    hero: Houseguest,
-    gameState: GameState,
-    compareFcn: (gameState: GameState, hero: Houseguest, villian: Houseguest) => number
-) {
-    const enemyCap = hero.popularity;
-    // we flip it to make it negative, since its something we as hero dislike
-    const centrailty = -compareFcn(gameState, hero, villian);
-    // do a linear transform on centrailty to have it be from -1 to enemyCap instead of from -1 to 1 /
-    const centrailtyTransformed = linear_transform(centrailty, -1, 1, -1, enemyCap);
-    hitList.push([villian.id, centrailtyTransformed, villian.name]);
-}
-
-function linear_transform(
-    x: number,
-    input_start: number,
-    input_end: number,
-    output_start: number,
-    output_end: number
-) {
-    return ((x - input_start) / (input_end - input_start)) * (output_end - output_start) + output_start;
-}
-
-function pushRelationship(hitList: [number, number, string][], villian: Houseguest, hero: Houseguest) {
-    hitList.push([villian.id, hero.relationshipWith(villian), villian.name]);
 }

--- a/src/components/episode/scenes/safetyChainScene.tsx
+++ b/src/components/episode/scenes/safetyChainScene.tsx
@@ -28,7 +28,7 @@ export function generateSafetyChainScene(initialGameState: GameState): [GameStat
     const sceneContent: JSX.Element[] = [];
     let first = true;
     while (chainOrder.length < safeSpots) {
-        const newSafeIndex = options.indexOf(getWorstTarget(currentChooser, options, newGameState));
+        const newSafeIndex = options.indexOf(getWorstTarget(currentChooser, options));
         chainOrder.push(options[newSafeIndex]);
         newGameState.currentLog.votes[currentChooser.id] = first
             ? new PoVvote(options[newSafeIndex].id)

--- a/src/components/episode/utilities/evictHouseguest.ts
+++ b/src/components/episode/utilities/evictHouseguest.ts
@@ -14,7 +14,7 @@ import { getFinalists } from "../../../model/season";
 import { average, roundTwoDigits } from "../../../utils";
 import { pHeroWinsTheFinale } from "../../../utils/ai/aiUtils";
 import { classifyRelationship, RelationshipType } from "../../../utils/ai/classifyRelationship";
-import { Targets } from "../../../utils/ai/targets";
+import { generateHitList } from "../../../utils/ai/hitList";
 
 export function evictHouseguest(gameState: MutableGameState, id: number): GameState {
     const evictee = getById(gameState, id);
@@ -85,7 +85,6 @@ function updatePopularity(houseguests: Houseguest[], updateDelta: boolean = fals
 
 function updateFriendCounts(houseguests: Houseguest[], gameState: GameState) {
     houseguests.forEach((hero: Houseguest) => {
-        let targets = new Targets(hero);
         let friends = 0;
         let enemies = 0;
         houseguests.forEach((villain) => {
@@ -103,12 +102,13 @@ function updateFriendCounts(houseguests: Houseguest[], gameState: GameState) {
         });
         hero.friends = friends;
         hero.enemies = enemies;
-        if (houseguests.length < 3) return;
-        // this stuff breaks if there are less than 3 players left
-        targets.refreshTargets(gameState, houseguests);
-        hero.targets = targets.getTargets();
-        hero.targets.forEach((target) => {
-            target >= 0 && getById(gameState, target).targetingMe++;
+        const hitList = generateHitList(hero, gameState);
+        hero.hitList = hitList;
+        const targets = [];
+        hero.hitList[0] && targets.push(hero.hitList[0].id);
+        hero.hitList[1] && targets.push(hero.hitList[1].id);
+        targets.forEach((target) => {
+            getById(gameState, target).targetingMe++;
         });
     });
 }

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -6,7 +6,7 @@ import {
     isBetterTarget,
     getRelationshipSummary,
     isBetterTargetWithLogic,
-    determineStrategy,
+    determineTargetStrategy,
     TargetStrategy,
 } from "../../../utils/ai/targets";
 
@@ -77,7 +77,7 @@ function useBoomerangVeto(
         return { decision: nominees[0], reason: "I want to save both of these noms." };
     }
     // if you would only use it on one of them, only use it if you have low friend counts
-    const strategy = determineStrategy(hero);
+    const strategy = determineTargetStrategy(hero);
     if (strategy === TargetStrategy.StatusQuo) {
         return { decision: null, reason: "I want to evict at least one of these noms." };
     } else {

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -2,13 +2,8 @@ import { every } from "lodash";
 import { Houseguest, GameState, exclude, getById, nonEvictedHousguestsSplit } from "../../../model";
 import { backdoorNPlayers, HouseguestWithLogic, NumberWithLogic } from "../../../utils/ai/aiApi";
 import { classifyRelationship, RelationshipType } from "../../../utils/ai/classifyRelationship";
-import {
-    shouldKillNew,
-    getRelationshipSummary,
-    selectTargetWithLogic,
-    determineTargetStrategy,
-    TargetStrategy,
-} from "../../../utils/ai/targets";
+import { shouldKillNew, selectTargetWithLogic, TargetStrategy } from "../../../utils/ai/targets";
+import { determineTargetStrategy } from "../../../utils/ai/hitList";
 
 export interface Veto {
     name: string;
@@ -96,17 +91,15 @@ function useSpotlightVeto(
     const checks = basicVetoChecks(hero, nominees, gameState, HoH, optionals);
     if (checks && checks.decision !== null) return checks;
     // use the veto on whoever is the worse target between the 2 nominees
-    const decision = selectTargetWithLogic(
-        getRelationshipSummary(hero, nominees[0]),
-        getRelationshipSummary(hero, nominees[1]),
+    const logic = selectTargetWithLogic(
+        nominees.map((hg) => hg.id),
         hero,
-        gameState,
         "good"
     );
-    return { decision: nominees[decision.decision], reason: decision.reason };
+    return { decision: getById(gameState, logic.decision), reason: logic.reason };
 }
 
-// TODO: fix this mess
+// TODO: fix this mess, save ppl on hit list above friendship threshold
 function useGoldenVeto(
     hero: Houseguest,
     nominees: Houseguest[],

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -3,9 +3,9 @@ import { Houseguest, GameState, exclude, getById, nonEvictedHousguestsSplit } fr
 import { backdoorNPlayers, HouseguestWithLogic, NumberWithLogic } from "../../../utils/ai/aiApi";
 import { classifyRelationship, RelationshipType } from "../../../utils/ai/classifyRelationship";
 import {
-    isBetterTarget,
+    shouldKillNew,
     getRelationshipSummary,
-    isBetterTargetWithLogic,
+    selectTargetWithLogic,
     determineTargetStrategy,
     TargetStrategy,
 } from "../../../utils/ai/targets";
@@ -96,16 +96,17 @@ function useSpotlightVeto(
     const checks = basicVetoChecks(hero, nominees, gameState, HoH, optionals);
     if (checks && checks.decision !== null) return checks;
     // use the veto on whoever is the worse target between the 2 nominees
-    const invertedDecision = isBetterTargetWithLogic(
+    const decision = selectTargetWithLogic(
         getRelationshipSummary(hero, nominees[0]),
         getRelationshipSummary(hero, nominees[1]),
         hero,
-        gameState
+        gameState,
+        "good"
     );
-    const decision = invertedDecision.decision === 0 ? 1 : 0;
-    return { decision: nominees[decision], reason: invertedDecision.reason };
+    return { decision: nominees[decision.decision], reason: decision.reason };
 }
 
+// TODO: fix this mess
 function useGoldenVeto(
     hero: Houseguest,
     nominees: Houseguest[],
@@ -174,7 +175,7 @@ function useDiamondVeto(
         };
     }
     // otherwise, replace the person i least want gone
-    const worseTarget: number = isBetterTarget(nominees[0].id, nominees[1].id, hero) ? 0 : 1;
+    const worseTarget: number = shouldKillNew(nominees[0].id, nominees[1].id, hero) ? 0 : 1;
 
     return { decision: nominees[worseTarget], reason: "I would rather see someone else nominated." };
 }

--- a/src/components/episode/veto/veto.tsx
+++ b/src/components/episode/veto/veto.tsx
@@ -174,14 +174,7 @@ function useDiamondVeto(
         };
     }
     // otherwise, replace the person i least want gone
-    const worseTarget: number = isBetterTarget(
-        getRelationshipSummary(hero, nominees[0]),
-        getRelationshipSummary(hero, nominees[1]),
-        hero,
-        gameState
-    )
-        ? 0
-        : 1;
+    const worseTarget: number = isBetterTarget(nominees[0].id, nominees[1].id, hero) ? 0 : 1;
 
     return { decision: nominees[worseTarget], reason: "I would rather see someone else nominated." };
 }

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -52,6 +52,11 @@ const twists: EpisodeType[] = [
 ];
 
 let lastJurySize = defaultJurySize(16);
+let lastHoHPlaysVeto = true;
+
+export function getLastHoHPlaysVeto(): boolean {
+    return lastHoHPlaysVeto;
+}
 
 export function getLastJurySize(): number {
     return lastJurySize;
@@ -79,7 +84,7 @@ function getInitialTribes(): Tribe[] {
 
 const submit = async (jury: number, hohPlaysVeto: boolean): Promise<void> => {
     lastJurySize = jury;
-
+    lastHoHPlaysVeto = hohPlaysVeto;
     const initialTribes = getInitialTribes();
     const cast = cast$.getValue();
     cast$.next({ ...cast, options: { initialTribes } });

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -27,6 +27,7 @@ import { getTeamsListContents, TeamsAdderList } from "./teamsAdderList";
 import { Tribe } from "../../model/tribe";
 import { SplitHouse } from "../episode/splitHouse";
 import { Tooltip } from "../tooltip/tooltip";
+import { BbAustralia } from "../episode/australiaEpisode";
 
 const Subheader = styled.h3`
     text-align: center;
@@ -49,6 +50,7 @@ const twists: EpisodeType[] = [
     CoHoH,
     BattleOfTheBlock,
     SplitHouse,
+    BbAustralia,
 ];
 
 let lastJurySize = defaultJurySize(16);

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -26,6 +26,7 @@ import { SafetyChain } from "../episode/safetyChain";
 import { getTeamsListContents, TeamsAdderList } from "./teamsAdderList";
 import { Tribe } from "../../model/tribe";
 import { SplitHouse } from "../episode/splitHouse";
+import { Tooltip } from "../tooltip/tooltip";
 
 const Subheader = styled.h3`
     text-align: center;
@@ -126,18 +127,26 @@ export function SeasonEditorPage(): JSX.Element {
                             margin: "10px",
                         }}
                     >
-                        <div className="field has-addons has-addons-centered" style={{ textAlign: "center" }}>
-                            <p className="field-label is-normal control">
-                                <Label className="label"> HoH Plays Veto?</Label>
-                            </p>
-                            <p className="control">
-                                <input
-                                    type="checkbox"
-                                    checked={hohPlaysVeto}
-                                    onChange={() => setHohPlaysVeto(!hohPlaysVeto)}
-                                />
-                            </p>
-                        </div>
+                        <Tooltip
+                            wide={true}
+                            text="Co-HoHs will still play in veto, but cannot veto their own nomination."
+                        >
+                            <div
+                                className="field has-addons has-addons-centered"
+                                style={{ textAlign: "center" }}
+                            >
+                                <p className="field-label is-normal control">
+                                    <Label className="label"> HoH Plays Veto?</Label>
+                                </p>
+                                <p className="control">
+                                    <input
+                                        type="checkbox"
+                                        checked={hohPlaysVeto}
+                                        onChange={() => setHohPlaysVeto(!hohPlaysVeto)}
+                                    />
+                                </p>
+                            </div>
+                        </Tooltip>
                     </div>
                     <div
                         className="column is-5-desktop is-5-widescreen is-5-fullhd is-12-tablet"

--- a/src/model/houseguest.ts
+++ b/src/model/houseguest.ts
@@ -1,6 +1,7 @@
 import { PlayerProfile } from "./playerProfile";
 import { RelationshipMap } from "../utils";
 import { Tribe } from "./tribe";
+import { HitList } from "../utils/ai/hitList";
 
 interface HouseguestInit extends PlayerProfile {
     id: number;
@@ -24,7 +25,7 @@ export class Houseguest extends PlayerProfile {
     public previousPopularity: number = 0;
     readonly relationships: RelationshipMap = {};
 
-    public targets: [number, number] = [this.id, this.id];
+    public hitList: HitList[] = [];
 
     // power rankings range from 0 to 1
     public powerRanking: number = 0;

--- a/src/model/houseguest.ts
+++ b/src/model/houseguest.ts
@@ -1,7 +1,7 @@
 import { PlayerProfile } from "./playerProfile";
 import { RelationshipMap } from "../utils";
 import { Tribe } from "./tribe";
-import { HitList } from "../utils/ai/hitList";
+import { HitListEntry } from "../utils/ai/hitList";
 
 interface HouseguestInit extends PlayerProfile {
     id: number;
@@ -25,7 +25,7 @@ export class Houseguest extends PlayerProfile {
     public previousPopularity: number = 0;
     readonly relationships: RelationshipMap = {};
 
-    public hitList: HitList[] = [];
+    public hitList: HitListEntry[] = [];
 
     // power rankings range from 0 to 1
     public powerRanking: number = 0;

--- a/src/model/logging/voteType.tsx
+++ b/src/model/logging/voteType.tsx
@@ -81,13 +81,15 @@ export class RunnerUpVote implements VoteType {
 export class NomineeVote implements VoteType {
     id: number = -1;
     evicted: boolean;
+    text: string;
     render = (state: GameState) => (
         <NomineeCell key={getKey()}>
-            <CenteredItallic noMargin={true}>Nominated</CenteredItallic>
+            <CenteredItallic noMargin={true}>{this.text}</CenteredItallic>
         </NomineeCell>
     );
-    constructor(evicted: boolean) {
+    constructor(evicted: boolean, text?: string) {
         this.evicted = evicted;
+        this.text = text || "Nominated";
     }
 }
 

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -1,6 +1,6 @@
 import { Houseguest, GameState, exclude, inJury } from "../../model";
 import { rng } from "../BbRandomGenerator";
-import { getRelationshipSummary, isBetterTarget, isBetterTargetWithLogic } from "./targets";
+import { getRelationshipSummary, shouldKillNew, selectTargetWithLogic } from "./targets";
 
 export interface NumberWithLogic {
     decision: number;
@@ -50,11 +50,12 @@ export function castEvictionVote(
     if (gameState.remainingPlayers === 4) {
         // prevents 4 player games from crashing LULW
         if (!inJury(gameState)) {
-            return isBetterTargetWithLogic(
+            return selectTargetWithLogic(
                 getRelationshipSummary(hero, nominees[0]),
                 getRelationshipSummary(hero, nominees[1]),
                 hero,
-                gameState
+                gameState,
+                "bad"
             );
         }
         return castF4vote(
@@ -70,11 +71,12 @@ export function castEvictionVote(
             )[0]
         );
     }
-    return isBetterTargetWithLogic(
+    return selectTargetWithLogic(
         getRelationshipSummary(hero, nominees[0]),
         getRelationshipSummary(hero, nominees[1]),
         hero,
-        gameState
+        gameState,
+        "bad"
     );
 }
 
@@ -126,7 +128,7 @@ export function getWorstTarget(hero: Houseguest, options: Houseguest[], gameStat
     const sortedOptions = [...options];
     // worst target is in position 0
     sortedOptions.sort((hg1, hg2) => {
-        return isBetterTarget(hg1.id, hg2.id, hero) ? -1 : 1;
+        return shouldKillNew(hg1.id, hg2.id, hero) ? -1 : 1;
     });
     if (sortedOptions.length === 0) throw "Tried to get a worst target from 0 options";
     return sortedOptions[0];
@@ -171,7 +173,7 @@ export function backdoorNPlayers(
     const sortedOptions = [...options];
     // negative value if first is less than second
     sortedOptions.sort((hg1, hg2) => {
-        return isBetterTarget(hg1.id, hg2.id, hero) ? 1 : -1;
+        return shouldKillNew(hg1.id, hg2.id, hero) ? 1 : -1;
     });
 
     while (result.length < n) {

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -126,14 +126,7 @@ export function getWorstTarget(hero: Houseguest, options: Houseguest[], gameStat
     const sortedOptions = [...options];
     // worst target is in position 0
     sortedOptions.sort((hg1, hg2) => {
-        return isBetterTarget(
-            getRelationshipSummary(hero, hg1),
-            getRelationshipSummary(hero, hg2),
-            hero,
-            gameState
-        )
-            ? -1
-            : 1;
+        return isBetterTarget(hg1.id, hg2.id, hero) ? -1 : 1;
     });
     if (sortedOptions.length === 0) throw "Tried to get a worst target from 0 options";
     return sortedOptions[0];
@@ -178,14 +171,7 @@ export function backdoorNPlayers(
     const sortedOptions = [...options];
     // negative value if first is less than second
     sortedOptions.sort((hg1, hg2) => {
-        return isBetterTarget(
-            getRelationshipSummary(hero, hg1),
-            getRelationshipSummary(hero, hg2),
-            hero,
-            gameState
-        )
-            ? 1
-            : -1;
+        return isBetterTarget(hg1.id, hg2.id, hero) ? 1 : -1;
     });
 
     while (result.length < n) {

--- a/src/utils/ai/aiApi.ts
+++ b/src/utils/ai/aiApi.ts
@@ -206,8 +206,7 @@ export function pJurorVotesForHero(juror: Houseguest, hero: Houseguest, villain:
     return result;
 }
 
-// Returns the index of the finalist with the highest relationship with juror
-// only works with 2 finalists
+// only works with 2 finalists, FIXME: make this work for 3+ finalists, by having the juror only vote between their top 2 choices.
 export function castJuryVote(juror: Houseguest, finalists: Houseguest[]): number {
     const choice = Math.abs(rng().randomFloat());
     return choice > pJurorVotesForHero(juror, finalists[0], finalists[1]) ? 1 : 0;

--- a/src/utils/ai/classifyRelationship.ts
+++ b/src/utils/ai/classifyRelationship.ts
@@ -1,3 +1,5 @@
+import { Houseguest } from "../../model";
+
 export enum RelationshipType {
     Friend = "FRIEND",
     Queen = "QUEEN",
@@ -11,6 +13,10 @@ export enum TwoWayRelationshipType {
 }
 
 export const RelationshipTypeToSymbol = { FRIEND: "♥", ENEMY: "💔", PAWN: "PAWN", QUEEN: "QUEEN" };
+
+export function classifyRelationshipHgs(hero: Houseguest, villain: Houseguest) {
+    return classifyRelationship(hero.popularity, villain.popularity, hero.relationshipWith(villain));
+}
 
 export function classifyRelationship(
     heroPopularity: number,

--- a/src/utils/ai/generateExcuse.ts
+++ b/src/utils/ai/generateExcuse.ts
@@ -1,0 +1,43 @@
+import { Houseguest } from "../../model";
+import {
+    TargetStrategy,
+    WinrateStrategy,
+    determineTargetStrategy,
+    determineWinrateStrategy,
+} from "./targets";
+
+export type Intent = "good" | "bad";
+
+export function generateExcuse(
+    hero: Houseguest,
+    decision: number,
+    options: number[],
+    intent: Intent
+): string {
+    const targetStrategy = determineTargetStrategy(hero);
+    const winrateStrategy = determineWinrateStrategy(hero);
+    if (winrateStrategy === WinrateStrategy.High) {
+        if (targetStrategy === TargetStrategy.Underdog) {
+            return "generateExcuse_high_underdog(hero, decision, options, intent);";
+        }
+        return generateExcuse_high_statusquo(hero, decision, options, intent);
+    } else if (winrateStrategy === WinrateStrategy.Medium) {
+        if (targetStrategy === TargetStrategy.Underdog)
+            return "generateExcuse_med_underdog(hero, decision, options, intent);";
+        return "generateExcuse_med_statusquo(hero, decision, options, intent);";
+    } else {
+        if (targetStrategy === TargetStrategy.Underdog)
+            return "generateExcuse_low_underdog(hero, decision, options, intent);";
+        return "generateExcuse_low_statusquo(hero, decision, options, intent);";
+    }
+}
+
+function generateExcuse_high_statusquo(
+    hero: Houseguest,
+    decision: number,
+    options: number[],
+    intent: Intent
+): string {
+    // TODO: a function based on relationship only... X is my friend, etc.
+    return " i felt likt it was the right thing to do";
+}

--- a/src/utils/ai/generateExcuse.ts
+++ b/src/utils/ai/generateExcuse.ts
@@ -1,10 +1,6 @@
 import { Houseguest } from "../../model";
-import {
-    TargetStrategy,
-    WinrateStrategy,
-    determineTargetStrategy,
-    determineWinrateStrategy,
-} from "./targets";
+import { determineTargetStrategy, determineWinrateStrategy } from "./hitList";
+import { TargetStrategy, WinrateStrategy } from "./targets";
 
 export type Intent = "good" | "bad";
 
@@ -14,13 +10,14 @@ export function generateExcuse(
     options: number[],
     intent: Intent
 ): string {
+    const name = hero.hitList.filter((hg) => hg.id === decision)[0].name;
     const targetStrategy = determineTargetStrategy(hero);
     const winrateStrategy = determineWinrateStrategy(hero);
     if (winrateStrategy === WinrateStrategy.High) {
         if (targetStrategy === TargetStrategy.Underdog) {
             return "generateExcuse_high_underdog(hero, decision, options, intent);";
         }
-        return generateExcuse_high_statusquo(hero, decision, options, intent);
+        return generateExcuse_high_statusquo(intent, name);
     } else if (winrateStrategy === WinrateStrategy.Medium) {
         if (targetStrategy === TargetStrategy.Underdog)
             return "generateExcuse_med_underdog(hero, decision, options, intent);";
@@ -32,12 +29,8 @@ export function generateExcuse(
     }
 }
 
-function generateExcuse_high_statusquo(
-    hero: Houseguest,
-    decision: number,
-    options: number[],
-    intent: Intent
-): string {
-    // TODO: a function based on relationship only... X is my friend, etc.
-    return " i felt likt it was the right thing to do";
+function generateExcuse_high_statusquo(intent: Intent, name: string): string {
+    // TODO: make this better
+    // TODO: triple eviction should use good intent somehow
+    return `I have a ${intent === "good" ? "better" : "worse"} relationship with ${name}.`;
 }

--- a/src/utils/ai/generateExcuse.ts
+++ b/src/utils/ai/generateExcuse.ts
@@ -4,33 +4,133 @@ import { TargetStrategy, WinrateStrategy } from "./targets";
 
 export type Intent = "good" | "bad";
 
-export function generateExcuse(
-    hero: Houseguest,
-    decision: number,
-    options: number[],
-    intent: Intent
-): string {
-    const name = hero.hitList.filter((hg) => hg.id === decision)[0].name;
+export function generateExcuse(hero: Houseguest, decision: number, intent: Intent): string {
+    const entry = hero.hitList.filter((hg) => hg.id === decision)[0];
+    const name = entry.name;
+    const popularity = hero.popularity;
+    const enemyValue = entry.value;
     const targetStrategy = determineTargetStrategy(hero);
     const winrateStrategy = determineWinrateStrategy(hero);
     if (winrateStrategy === WinrateStrategy.High) {
         if (targetStrategy === TargetStrategy.Underdog) {
-            return "generateExcuse_high_underdog(hero, decision, options, intent);";
+            return generateExcuse_high_underdog(intent, name, enemyValue, popularity);
         }
         return generateExcuse_high_statusquo(intent, name);
     } else if (winrateStrategy === WinrateStrategy.Medium) {
         if (targetStrategy === TargetStrategy.Underdog)
-            return "generateExcuse_med_underdog(hero, decision, options, intent);";
-        return "generateExcuse_med_statusquo(hero, decision, options, intent);";
+            return generateExcuse_med_underdog(intent, name, enemyValue, popularity);
+        return generateExcuse_med_statusquo(intent, name, enemyValue, popularity);
     } else {
         if (targetStrategy === TargetStrategy.Underdog)
-            return "generateExcuse_low_underdog(hero, decision, options, intent);";
-        return "generateExcuse_low_statusquo(hero, decision, options, intent);";
+            return generateExcuse_low_underdog(intent, name, enemyValue, popularity);
+        return generateExcuse_low_statusquo(intent, name);
     }
 }
 
 function generateExcuse_high_statusquo(intent: Intent, name: string): string {
-    // TODO: make this better
-    // TODO: triple eviction should use good intent somehow
     return `I have a ${intent === "good" ? "better" : "worse"} relationship with ${name}.`;
+}
+
+function generateExcuse_low_statusquo(intent: Intent, name: string): string {
+    return `I have ${intent === "good" ? "better" : "worse"} odds of beating ${name} in the end.`;
+}
+
+function getQuarterpoints(popularity: number): number[] {
+    // midpoint between popularity and `1
+    const pos = (popularity + 1) / 2;
+    // midpoint between popularity and -1
+    const neg = (popularity - 1) / 2;
+    return [neg, popularity, pos];
+}
+
+// high underdog: {enemies by centrality} {friends by rel.}
+function generateExcuse_high_underdog(
+    intent: Intent,
+    name: string,
+    enemyValue: number,
+    popularity: number
+): string {
+    if (enemyValue < popularity) {
+        return intent === "bad"
+            ? `${name} is popular among my enemies.`
+            : `${name} is the least threatening of these enemies.`;
+    } else {
+        return intent === "bad" ? `Of these friends, I am least close to ${name}.` : `${name} is my friend.`;
+    }
+}
+
+// low underdog: {enemies i can't beat, sorted by centrality} {friends i can't beat, by rel.} {enemies i can beat, by centrality} {friends i can beat, by rel.}
+function generateExcuse_low_underdog(
+    intent: Intent,
+    name: string,
+    enemyValue: number,
+    popularity: number
+): string {
+    const quarterpoints = getQuarterpoints(popularity);
+    if (enemyValue < quarterpoints[0]) {
+        return enemyIcannotBeatbyCentrality(intent, name);
+    } else if (enemyValue < quarterpoints[1]) {
+        return friendIcannotBeatbyRelationship(intent, name);
+    } else if (enemyValue < quarterpoints[2]) {
+        return enemyIcanBeatbyCentrality(intent, name);
+    } else {
+        return friendIcanBeatbyRelationship(intent, name);
+    }
+}
+
+// med underdog: {enemies i can't beat; by cent.} {enemies i can beat; by cent.} {friends i can't beat; by rel} {friends i can beat; by rel}
+function generateExcuse_med_underdog(
+    intent: Intent,
+    name: string,
+    enemyValue: number,
+    popularity: number
+): string {
+    const quarterpoints = getQuarterpoints(popularity);
+    if (enemyValue < quarterpoints[0]) {
+        return enemyIcannotBeatbyCentrality(intent, name);
+    } else if (enemyValue < quarterpoints[1]) {
+        return enemyIcanBeatbyCentrality(intent, name);
+    } else if (enemyValue < quarterpoints[2]) {
+        return friendIcannotBeatbyRelationship(intent, name);
+    } else {
+        return friendIcanBeatbyRelationship(intent, name);
+    }
+}
+
+// med statusquo: {enemies; by winrate.} {friends; by winrate.}
+function generateExcuse_med_statusquo(
+    intent: Intent,
+    name: string,
+    enemyValue: number,
+    popularity: number
+): string {
+    if (enemyValue < popularity) {
+        return intent === "bad"
+            ? `${name} is my enemy.`
+            : `${name} is my enemy, but I have a better chance of beating them in the end.`;
+    } else {
+        return intent === "bad"
+            ? `${name} is my friend, but I have a worse chance of beating them in the end.`
+            : `${name} is my friend.`;
+    }
+}
+
+function friendIcanBeatbyRelationship(intent: Intent, name: string) {
+    return intent === "bad"
+        ? `Of these friends, I am least close to ${name}.`
+        : `${name} is my friend, and I can beat them in the end.`;
+}
+
+function friendIcannotBeatbyRelationship(intent: Intent, name: string) {
+    return intent === "bad" ? `I can't beat ${name} in the end.` : `${name} is my friend.`;
+}
+
+function enemyIcannotBeatbyCentrality(intent: Intent, name: string) {
+    return intent === "bad"
+        ? `${name} is popular among my enemies, and I can't beat them in the end.`
+        : `${name} is the least threatening of these enemies.`;
+}
+
+function enemyIcanBeatbyCentrality(intent: Intent, name: string) {
+    return intent === "bad" ? `${name} is more popular among my enemies.` : `I can beat ${name} in the end.`;
 }

--- a/src/utils/ai/hitList.ts
+++ b/src/utils/ai/hitList.ts
@@ -20,9 +20,7 @@ export function generateHitList(hero: Houseguest, gameState: GameState): HitList
     const s = (a: any, b: any) => a.value - b.value;
     const targetStrategy: TargetStrategy = determineTargetStrategy(hero);
 
-    const winrateStrategy: WinrateStrategy = !inJury(gameState)
-        ? WinrateStrategy.High
-        : determineWinrateStrategy(hero);
+    const winrateStrategy: WinrateStrategy = determineWinrateStrategy(hero);
 
     if (winrateStrategy === WinrateStrategy.High) {
         if (targetStrategy === TargetStrategy.Underdog)

--- a/src/utils/ai/hitList.ts
+++ b/src/utils/ai/hitList.ts
@@ -1,18 +1,51 @@
-import { GameState, nonEvictedHouseguests } from "../../model/gameState";
+import { GameState, inJury, nonEvictedHouseguests } from "../../model/gameState";
 import { Houseguest } from "../../model";
 import { RelationshipType, classifyRelationshipHgs } from "./classifyRelationship";
-import { computeEnemyCentrality, computeNonfriendCentrality } from "./targets";
+import {
+    TargetStrategy,
+    WinrateStrategy,
+    computeEnemyCentrality,
+    computeNonfriendCentrality,
+    determineTargetStrategy,
+    determineWinrateStrategy,
+} from "./targets";
 
-// TODO: move tihs somewhere else
-export function generateHitList(hero: Houseguest, gameState: GameState) {
+export function generateHitList(hero: Houseguest, gameState: GameState): [number, number, string][] {
     const list: [number, number, string][] = [];
     const s = (a: any, b: any) => a[1] - b[1];
+    const targetStrategy: TargetStrategy = determineTargetStrategy(hero);
 
-    // now do High / MoR
-    if (hero.friends === hero.enemies) return generateHitList_high_MoR(list, hero, gameState).sort(s);
-    if (hero.friends < hero.enemies) return generateHitList_high_underdog(list, hero, gameState).sort(s);
-    return generateHitList_high_statusquo(list, hero, gameState).sort(s);
+    const winrateStrategy: WinrateStrategy = !inJury(gameState)
+        ? WinrateStrategy.High
+        : determineWinrateStrategy(hero);
+
+    if (winrateStrategy === WinrateStrategy.High) {
+        if (targetStrategy === TargetStrategy.MoR)
+            return generateHitList_high_MoR(list, hero, gameState).sort(s);
+        if (targetStrategy === TargetStrategy.Underdog)
+            return generateHitList_high_underdog(list, hero, gameState).sort(s);
+        return generateHitList_high_statusquo(list, hero, gameState).sort(s);
+    } else if (winrateStrategy === WinrateStrategy.Medium) {
+        return generateHitList_med_statusquo(list, hero, gameState).sort(s);
+    } else {
+        // low
+    }
+    return [];
 }
+
+function generateHitList_med_statusquo(
+    hitList: [number, number, string][],
+    hero: Houseguest,
+    gameState: GameState
+) {
+    for (const villian of nonEvictedHouseguests(gameState)) {
+        if (hero.id === villian.id) continue;
+        pushWinrateWithinRelationshipTier(hitList, villian, hero);
+    }
+    console.log("!!!!!!!");
+    return hitList;
+}
+
 function generateHitList_high_underdog(
     hitList: [number, number, string][],
     hero: Houseguest,
@@ -80,4 +113,27 @@ function linear_transform(
 }
 function pushRelationship(hitList: [number, number, string][], villian: Houseguest, hero: Houseguest) {
     hitList.push([villian.id, hero.relationshipWith(villian), villian.name]);
+}
+
+function pushWinrateWithinRelationshipTier(
+    hitList: [number, number, string][],
+    villian: Houseguest,
+    hero: Houseguest
+) {
+    const relationshipType: RelationshipType = classifyRelationshipHgs(hero, villian);
+    if (relationshipType !== RelationshipType.Friend) {
+        // map below the enemy space
+        hitList.push([
+            villian.id,
+            linear_transform(hero.superiors[villian.id], 0, 1, -1, hero.popularity),
+            villian.name,
+        ]);
+    } else {
+        // map above the enemy space
+        hitList.push([
+            villian.id,
+            linear_transform(hero.superiors[villian.id], 0, 1, hero.popularity, 1),
+            villian.name,
+        ]);
+    }
 }

--- a/src/utils/ai/hitList.ts
+++ b/src/utils/ai/hitList.ts
@@ -8,6 +8,7 @@ import {
     determineTargetStrategy,
     determineWinrateStrategy,
 } from "./targets";
+import { linear_transform } from "../utilities";
 
 export interface HitList {
     id: number;
@@ -158,19 +159,10 @@ function pushEnemyCentrailty(
 ) {
     // we flip it to make it negative, since its something we as hero dislike
     const centrailty = -computeEnemyCentrality(gameState, hero, villian);
-    // do a linear transform on centrailty to have it be from -1 to enemyCap instead of from -1 to 1 /
     const value = linear_transform(centrailty, -1, 1, -1, hero.popularity);
     hitList.push({ id: villian.id, value });
 }
-function linear_transform(
-    x: number,
-    input_start: number,
-    input_end: number,
-    output_start: number,
-    output_end: number
-) {
-    return ((x - input_start) / (input_end - input_start)) * (output_end - output_start) + output_start;
-}
+
 function pushRelationship(hitList: HitList[], villian: Houseguest, hero: Houseguest) {
     hitList.push({ id: villian.id, value: hero.relationshipWith(villian) });
 }

--- a/src/utils/ai/hitList.ts
+++ b/src/utils/ai/hitList.ts
@@ -9,6 +9,14 @@ export interface HitListEntry {
     value: number;
     name: string;
 }
+
+export function getFromHitlist(hitList: HitListEntry[], id: number): HitListEntry {
+    for (const entry of hitList) {
+        if (entry.id === id) return entry;
+    }
+    throw new Error(`getFromHitlist: ${id} not found in hitlist`);
+}
+
 export function determineWinrateStrategy(hero: Houseguest): WinrateStrategy {
     if (hero.powerRanking <= 0) return WinrateStrategy.High; // For pre-jury gameplay, or people who are drawing 100% dead
     if (hero.powerRanking >= 0.45) return WinrateStrategy.High;

--- a/src/utils/ai/hitList.ts
+++ b/src/utils/ai/hitList.ts
@@ -1,0 +1,83 @@
+import { GameState, nonEvictedHouseguests } from "../../model/gameState";
+import { Houseguest } from "../../model";
+import { RelationshipType, classifyRelationshipHgs } from "./classifyRelationship";
+import { computeEnemyCentrality, computeNonfriendCentrality } from "./targets";
+
+// TODO: move tihs somewhere else
+export function generateHitList(hero: Houseguest, gameState: GameState) {
+    const list: [number, number, string][] = [];
+    const s = (a: any, b: any) => a[1] - b[1];
+
+    // now do High / MoR
+    if (hero.friends === hero.enemies) return generateHitList_high_MoR(list, hero, gameState).sort(s);
+    if (hero.friends < hero.enemies) return generateHitList_high_underdog(list, hero, gameState).sort(s);
+    return generateHitList_high_statusquo(list, hero, gameState).sort(s);
+}
+function generateHitList_high_underdog(
+    hitList: [number, number, string][],
+    hero: Houseguest,
+    gameState: GameState
+) {
+    for (const villian of nonEvictedHouseguests(gameState)) {
+        if (hero.id === villian.id) continue;
+        if (classifyRelationshipHgs(hero, villian) !== RelationshipType.Friend) {
+            pushEnemyCentrailty(hitList, villian, hero, gameState, computeNonfriendCentrality);
+        } else {
+            pushRelationship(hitList, villian, hero);
+        }
+    }
+    return hitList;
+}
+// enemies are sorted by centrailty, non-enemies are normal
+function generateHitList_high_MoR(
+    hitList: [number, number, string][],
+    hero: Houseguest,
+    gameState: GameState
+) {
+    for (const villian of nonEvictedHouseguests(gameState)) {
+        if (hero.id === villian.id) continue;
+        if (classifyRelationshipHgs(hero, villian) === RelationshipType.Enemy) {
+            pushEnemyCentrailty(hitList, villian, hero, gameState, computeEnemyCentrality);
+        } else {
+            pushRelationship(hitList, villian, hero);
+        }
+    }
+    return hitList;
+}
+function generateHitList_high_statusquo(
+    hitList: [number, number, string][],
+    hero: Houseguest,
+    gameState: GameState
+) {
+    for (const villian of nonEvictedHouseguests(gameState)) {
+        if (hero.id === villian.id) continue;
+        pushRelationship(hitList, villian, hero);
+    }
+    return hitList;
+}
+function pushEnemyCentrailty(
+    hitList: [number, number, string][],
+    villian: Houseguest,
+    hero: Houseguest,
+    gameState: GameState,
+    compareFcn: (gameState: GameState, hero: Houseguest, villian: Houseguest) => number
+) {
+    const enemyCap = hero.popularity;
+    // we flip it to make it negative, since its something we as hero dislike
+    const centrailty = -compareFcn(gameState, hero, villian);
+    // do a linear transform on centrailty to have it be from -1 to enemyCap instead of from -1 to 1 /
+    const centrailtyTransformed = linear_transform(centrailty, -1, 1, -1, enemyCap);
+    hitList.push([villian.id, centrailtyTransformed, villian.name]);
+}
+function linear_transform(
+    x: number,
+    input_start: number,
+    input_end: number,
+    output_start: number,
+    output_end: number
+) {
+    return ((x - input_start) / (input_end - input_start)) * (output_end - output_start) + output_start;
+}
+function pushRelationship(hitList: [number, number, string][], villian: Houseguest, hero: Houseguest) {
+    hitList.push([villian.id, hero.relationshipWith(villian), villian.name]);
+}

--- a/src/utils/ai/hitList.ts
+++ b/src/utils/ai/hitList.ts
@@ -1,19 +1,23 @@
 import { GameState, nonEvictedHouseguests } from "../../model/gameState";
 import { Houseguest } from "../../model";
 import { RelationshipType, classifyRelationshipHgs } from "./classifyRelationship";
-import {
-    TargetStrategy,
-    WinrateStrategy,
-    computeEnemyCentrality,
-    determineTargetStrategy,
-    determineWinrateStrategy,
-} from "./targets";
+import { TargetStrategy, WinrateStrategy, computeEnemyCentrality } from "./targets";
 import { linear_transform } from "../utilities";
 
 export interface HitListEntry {
     id: number;
     value: number;
     name: string;
+}
+export function determineWinrateStrategy(hero: Houseguest): WinrateStrategy {
+    if (hero.powerRanking <= 0) return WinrateStrategy.High; // For pre-jury gameplay, or people who are drawing 100% dead
+    if (hero.powerRanking >= 0.45) return WinrateStrategy.High;
+    if (hero.powerRanking <= 1 / 3) return WinrateStrategy.Low;
+    return WinrateStrategy.Medium;
+}
+
+export function determineTargetStrategy(hero: Houseguest): TargetStrategy {
+    return hero.friends > hero.enemies ? TargetStrategy.StatusQuo : TargetStrategy.Underdog;
 }
 
 export function generateHitList(hero: Houseguest, gameState: GameState): HitListEntry[] {
@@ -193,10 +197,3 @@ function pushWinrateWithinRelationshipTier(hitList: HitListEntry[], villian: Hou
         });
     }
 }
-
-// TODO: here's what we're going to do. abandon targets.ts, instead make a generateExcuse() function, where given a decision and a list of hgs, and a hero,
-// give an excuse for why hero made the decision. also it could be a positive or negative decision (veto/vote to save or voting someone out)  /
-
-// TODO: also for veto, save people whom in your hit list are above your friendship threshold
-
-// function generateReason(hero: Houseguest, , gameState: GameState) {

--- a/src/utils/ai/hitList.ts
+++ b/src/utils/ai/hitList.ts
@@ -125,7 +125,7 @@ function generateHitList_med_underdog(hitList: HitListEntry[], hero: Houseguest,
             const centrailty = -computeEnemyCentrality(gameState, hero, villian);
             const midpoint = (hero.popularity - 1) / 2;
             const output_start = heroWins ? midpoint : hero.popularity;
-            const output_end = heroWins ? 1 : midpoint;
+            const output_end = heroWins ? hero.popularity : midpoint;
             const centrailtyTransformed = linear_transform(
                 centrailty,
                 -1,

--- a/src/utils/ai/hitList.ts
+++ b/src/utils/ai/hitList.ts
@@ -42,6 +42,7 @@ export function generateHitList(hero: Houseguest, gameState: GameState): HitList
     }
 }
 
+// low statusquo: vote solely based on winrate
 function generateHitList_low_statusquo(hitList: HitListEntry[], hero: Houseguest, gameState: GameState) {
     for (const villian of nonEvictedHouseguests(gameState)) {
         if (hero.id === villian.id) continue;
@@ -50,6 +51,7 @@ function generateHitList_low_statusquo(hitList: HitListEntry[], hero: Houseguest
     return hitList;
 }
 
+// low underdog: {enemies i can't beat, sorted by centrality} {friends i can't beat, by rel.} {enemies i can beat, by centrality} {friends i can beat, by rel.}
 function generateHitList_low_underdog(hitList: HitListEntry[], hero: Houseguest, gameState: GameState) {
     for (const villian of nonEvictedHouseguests(gameState)) {
         if (hero.id === villian.id) continue;
@@ -90,6 +92,7 @@ function generateHitList_low_underdog(hitList: HitListEntry[], hero: Houseguest,
     return hitList;
 }
 
+// med underdog: {enemies i can't beat; by cent.} {enemies i can beat; by cent.} {friends i can't beat; by rel} {friends i can beat; by rel}
 function generateHitList_med_underdog(hitList: HitListEntry[], hero: Houseguest, gameState: GameState) {
     for (const villian of nonEvictedHouseguests(gameState)) {
         if (hero.id === villian.id) continue;
@@ -128,6 +131,7 @@ function generateHitList_med_underdog(hitList: HitListEntry[], hero: Houseguest,
     return hitList;
 }
 
+// med statusquo: {enemies; by winrate.} {friends; by winrate.}
 function generateHitList_med_statusquo(hitList: HitListEntry[], hero: Houseguest, gameState: GameState) {
     for (const villian of nonEvictedHouseguests(gameState)) {
         if (hero.id === villian.id) continue;
@@ -136,6 +140,7 @@ function generateHitList_med_statusquo(hitList: HitListEntry[], hero: Houseguest
     return hitList;
 }
 
+// high underdog: {enemies by centrality} {friends by rel.}
 function generateHitList_high_underdog(hitList: HitListEntry[], hero: Houseguest, gameState: GameState) {
     for (const villian of nonEvictedHouseguests(gameState)) {
         if (hero.id === villian.id) continue;
@@ -148,6 +153,7 @@ function generateHitList_high_underdog(hitList: HitListEntry[], hero: Houseguest
     return hitList;
 }
 
+// high statusquo: {all by relationship}
 function generateHitList_high_statusquo(hitList: HitListEntry[], hero: Houseguest, gameState: GameState) {
     for (const villian of nonEvictedHouseguests(gameState)) {
         if (hero.id === villian.id) continue;

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -73,7 +73,7 @@ export enum TargetStrategy {
     MoR,
 }
 
-function determineWinrateStrategy(hero: Houseguest): WinrateStrategy {
+export function determineWinrateStrategy(hero: Houseguest): WinrateStrategy {
     if (hero.powerRanking >= 0.45) return WinrateStrategy.High;
     if (hero.powerRanking <= 1 / 3) return WinrateStrategy.Low;
     return WinrateStrategy.Medium;

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -67,13 +67,14 @@ export function isBetterTargetWithLogic(
     }
 }
 
-export function isBetterTarget(
-    old: RelationshipSummary,
-    neww: RelationshipSummary,
-    hero: Houseguest,
-    gameState: GameState
-): boolean {
-    return isBetterTargetWithLogic(old, neww, hero, gameState).decision === 1;
+// returns true if neww is a better target than old
+export function isBetterTarget(old: number, neww: number, hero: Houseguest): boolean {
+    for (const hit of hero.hitList) {
+        if (hit.id === old) return false;
+        if (hit.id === neww) return true;
+    }
+    console.error(hero.hitList);
+    throw new Error(`isBetterTarget: hitlist of ${hero} tried to find ${old} or ${neww} but couldn't`);
 }
 
 function voteBasedOnCentrality(

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -288,7 +288,7 @@ function voteBasedonWinrate(
 ): NumberWithLogic {
     const heroBeatsnom0 = hero.powerRanking < hero.superiors[nom0.id];
     const heroBeatsnom1 = hero.powerRanking < hero.superiors[nom1.id];
-    // if i am voting between 2 people who i can't beat, vote based on relationship
+    // if i am voting between 2 people who i can't beat, vote based on callback
     if (!heroBeatsnom0 && !heroBeatsnom1) {
         return callback(hero, [nom0, nom1]);
     }

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -60,7 +60,7 @@ export class Targets {
     }
 }
 
-enum WinrateStrategy {
+export enum WinrateStrategy {
     Low,
     Medium,
     High,
@@ -79,7 +79,7 @@ export function determineWinrateStrategy(hero: Houseguest): WinrateStrategy {
     return WinrateStrategy.Medium;
 }
 
-export function determineStrategy(hero: Houseguest): TargetStrategy {
+export function determineTargetStrategy(hero: Houseguest): TargetStrategy {
     if (hero.friends === hero.enemies) return TargetStrategy.MoR;
     return hero.friends > hero.enemies ? TargetStrategy.StatusQuo : TargetStrategy.Underdog;
 }
@@ -93,7 +93,7 @@ export function isBetterTargetWithLogic(
 ): NumberWithLogic {
     if (old.relationship === 2) return { decision: 1, reason: "remove debug value" };
     if (neww.relationship === 2) return { decision: 0, reason: "remove debug value" };
-    const strategy = determineStrategy(hero);
+    const strategy = determineTargetStrategy(hero);
     const winrateStrategy = determineWinrateStrategy(hero);
     if (strategy === TargetStrategy.StatusQuo)
         return isBetterTargetStatusQuo(hero, old, neww, winrateStrategy, gameState);

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -1,33 +1,8 @@
-import { GameState, getById, Houseguest, inJury } from "../../model";
+import { GameState, getById, Houseguest } from "../../model";
 import { NumberWithLogic } from "./aiApi";
-import { lowestScore, relationship } from "./aiUtils";
-import { classifyRelationship, classifyTwoWayRelationship, RelationshipType } from "./classifyRelationship";
+import { classifyRelationship, RelationshipType } from "./classifyRelationship";
 import { generateExcuse, Intent } from "./generateExcuse";
-
-interface RelationshipSummary {
-    type: RelationshipType;
-    relationship: number;
-    winrate: number;
-    id: number;
-    pHeroWins: number;
-    villainPopularity: number;
-    villianName: string;
-}
-
-// TODO: try to kill this
-export function getRelationshipSummary(hero: Houseguest, villain: Houseguest): RelationshipSummary {
-    const doIWin = hero.superiors[villain.id];
-    const type = classifyRelationship(hero.popularity, villain.popularity, hero.relationships[villain.id]);
-    return {
-        id: villain.id,
-        relationship: villain.relationships[hero.id],
-        type,
-        winrate: hero.powerRanking,
-        pHeroWins: doIWin,
-        villainPopularity: villain.popularity,
-        villianName: villain.name,
-    };
-}
+import { HitListEntry } from "./hitList";
 
 export enum WinrateStrategy {
     Low,
@@ -41,45 +16,23 @@ export enum TargetStrategy {
     Underdog,
 }
 
-// TODO: move this to hitlist.ts
-export function determineWinrateStrategy(hero: Houseguest): WinrateStrategy {
-    if (hero.powerRanking <= 0) return WinrateStrategy.High; // For pre-jury gameplay, or people who are drawing 100% dead
-    if (hero.powerRanking >= 0.45) return WinrateStrategy.High;
-    if (hero.powerRanking <= 1 / 3) return WinrateStrategy.Low;
-    return WinrateStrategy.Medium;
-}
-
-// TODO: move this to hitlist.ts
-export function determineTargetStrategy(hero: Houseguest): TargetStrategy {
-    return hero.friends > hero.enemies ? TargetStrategy.StatusQuo : TargetStrategy.Underdog;
-}
-
-// return the index of the intended target //
-// 0 if the old target is better, 1 if the new target is better
-export function selectTargetWithLogic(
-    old: RelationshipSummary,
-    neww: RelationshipSummary,
-    hero: Houseguest,
-    gameState: GameState,
-    intent: Intent
-): NumberWithLogic {
-    // TODO: please do better than this, just use the hit list + excuse generating fcn
+// returns the id of the best target
+export function selectTargetWithLogic(options: number[], hero: Houseguest, intent: Intent): NumberWithLogic {
     const badIntent = intent === "bad";
-    const decision = shouldKillNew(old.id, neww.id, hero) === badIntent ? 1 : 0;
-    const reason = generateExcuse(hero, decision, [old.id, neww.id], "bad");
+    const decide = badIntent ? mostDesiredTarget : leastDesiredTarget;
+    const decision = decide(hero.hitList, new Set(options)).id;
+    const reason = generateExcuse(hero, decision, options, intent);
     return { decision, reason };
-
-    if (old.relationship === 2) return { decision: 1, reason: "remove debug value" };
-    if (neww.relationship === 2) return { decision: 0, reason: "remove debug value" };
-    const strategy = determineTargetStrategy(hero);
-    const winrateStrategy = determineWinrateStrategy(hero);
-    if (strategy === TargetStrategy.StatusQuo)
-        return isBetterTargetStatusQuo(hero, old, neww, winrateStrategy, gameState);
-    else {
-        return isBetterTargetUnderdog(old, neww, gameState, hero, winrateStrategy);
-    }
 }
 
+function mostDesiredTarget(hitList: HitListEntry[], options: Set<number>): HitListEntry {
+    return hitList.filter((x) => options.has(x.id))[0];
+}
+
+function leastDesiredTarget(hitList: HitListEntry[], options: Set<number>): HitListEntry {
+    const result = hitList.filter((x) => options.has(x.id));
+    return result[result.length - 1];
+}
 // returns true if neww is less valued on the hit list than old
 export function shouldKillNew(old: number, neww: number, hero: Houseguest): boolean {
     for (const hit of hero.hitList) {
@@ -90,85 +43,85 @@ export function shouldKillNew(old: number, neww: number, hero: Houseguest): bool
     throw new Error(`isBetterTarget: hitlist of ${hero} tried to find ${old} or ${neww} but couldn't`);
 }
 
-function voteBasedOnCentrality(
-    gameState: GameState,
-    internalCallback: (x: RelationshipType) => boolean
-): (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]) => NumberWithLogic {
-    return (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]): NumberWithLogic => {
-        const decision = isMoreCentral(hero, nominees[0], nominees[1], gameState, internalCallback) ? 1 : 0;
-        return {
-            decision,
-            reason: `${[nominees[0], nominees[1]][decision].villianName} is more popular among my enemies.`,
-        };
-    };
-}
+// function voteBasedOnCentrality(
+//     gameState: GameState,
+//     internalCallback: (x: RelationshipType) => boolean
+// ): (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]) => NumberWithLogic {
+//     return (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]): NumberWithLogic => {
+//         const decision = isMoreCentral(hero, nominees[0], nominees[1], gameState, internalCallback) ? 1 : 0;
+//         return {
+//             decision,
+//             reason: `${[nominees[0], nominees[1]][decision].villianName} is more popular among my enemies.`,
+//         };
+//     };
+// }
 
-function targetNonfriends(
-    hero: Houseguest,
-    old: RelationshipSummary,
-    neww: RelationshipSummary,
-    callback: (
-        hero: Houseguest,
-        nominees: [RelationshipSummary, RelationshipSummary],
-        callback?: (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]) => NumberWithLogic
-    ) => NumberWithLogic
-): NumberWithLogic {
-    if (old.type === RelationshipType.Friend) return _targetNonfriends();
-    if (neww.type === RelationshipType.Friend)
-        return { decision: 0, reason: `${old.villianName} is not my friend.` };
-    return callback(hero, [old, neww]);
+// function targetNonfriends(
+//     hero: Houseguest,
+//     old: RelationshipSummary,
+//     neww: RelationshipSummary,
+//     callback: (
+//         hero: Houseguest,
+//         nominees: [RelationshipSummary, RelationshipSummary],
+//         callback?: (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]) => NumberWithLogic
+//     ) => NumberWithLogic
+// ): NumberWithLogic {
+//     if (old.type === RelationshipType.Friend) return _targetNonfriends();
+//     if (neww.type === RelationshipType.Friend)
+//         return { decision: 0, reason: `${old.villianName} is not my friend.` };
+//     return callback(hero, [old, neww]);
 
-    function _targetNonfriends() {
-        // runs if old is not an enemy -> runs if old is not an enemy or neutral
-        const decision = (neww.type !== RelationshipType.Friend ? true : neww.relationship < old.relationship)
-            ? 1
-            : 0;
-        return {
-            decision,
-            reason: `I like ${[old, neww][decision].villianName} the least of these noms.`,
-        };
-    }
-}
+//     function _targetNonfriends() {
+//         // runs if old is not an enemy -> runs if old is not an enemy or neutral
+//         const decision = (neww.type !== RelationshipType.Friend ? true : neww.relationship < old.relationship)
+//             ? 1
+//             : 0;
+//         return {
+//             decision,
+//             reason: `I like ${[old, neww][decision].villianName} the least of these noms.`,
+//         };
+//     }
+// }
 
 const underdogStrategy = (x: RelationshipType) => x !== RelationshipType.Friend;
-function isBetterTargetUnderdog(
-    old: RelationshipSummary,
-    neww: RelationshipSummary,
-    gameState: GameState,
-    hero: Houseguest,
-    winrateStrategy: WinrateStrategy
-): NumberWithLogic {
-    if (winrateStrategy === WinrateStrategy.High || !inJury(gameState)) {
-        // prioritize targeting enemies, break ties based on enemy centrality
-        return targetNonfriends(hero, old, neww, voteBasedOnCentrality(gameState, underdogStrategy));
-    } else if (winrateStrategy === WinrateStrategy.Medium) {
-        // prioritize targeting enemies, break ties based on if i can beat them, then break further ties based on centrality
-        return targetNonfriends(hero, old, neww, (hero, [old, neww]) =>
-            voteBasedonWinrate(hero, old, neww, voteBasedOnCentrality(gameState, underdogStrategy))
-        );
-    } else {
-        // prioritize targeting high winrate, break ties based on friend/enemy status, then centrality
-        return voteBasedonWinrate(hero, old, neww, (hero, [old, neww]) =>
-            targetNonfriends(hero, old, neww, voteBasedOnCentrality(gameState, underdogStrategy))
-        );
-    }
-}
+// function isBetterTargetUnderdog(
+//     old: RelationshipSummary,
+//     neww: RelationshipSummary,
+//     gameState: GameState,
+//     hero: Houseguest,
+//     winrateStrategy: WinrateStrategy
+// ): NumberWithLogic {
+//     if (winrateStrategy === WinrateStrategy.High || !inJury(gameState)) {
+//         // prioritize targeting enemies, break ties based on enemy centrality
+//         return targetNonfriends(hero, old, neww, voteBasedOnCentrality(gameState, underdogStrategy));
+//     } else if (winrateStrategy === WinrateStrategy.Medium) {
+//         // prioritize targeting enemies, break ties based on if i can beat them, then break further ties based on centrality
+//         return targetNonfriends(hero, old, neww, (hero, [old, neww]) =>
+//             voteBasedonWinrate(hero, old, neww, voteBasedOnCentrality(gameState, underdogStrategy))
+//         );
+//     } else {
+//         // prioritize targeting high winrate, break ties based on friend/enemy status, then centrality
+//         return voteBasedonWinrate(hero, old, neww, (hero, [old, neww]) =>
+//             targetNonfriends(hero, old, neww, voteBasedOnCentrality(gameState, underdogStrategy))
+//         );
+//     }
+// }
 
 // returns true if neww is more central than old
-function isMoreCentral(
-    hero: Houseguest,
-    old: RelationshipSummary,
-    neww: RelationshipSummary,
-    gameState: GameState,
-    condition: (x: RelationshipType) => boolean
-): boolean {
-    const oldHg: Houseguest = getById(gameState, old.id);
-    const newHg: Houseguest = getById(gameState, neww.id);
+// function isMoreCentral(
+//     hero: Houseguest,
+//     old: RelationshipSummary,
+//     neww: RelationshipSummary,
+//     gameState: GameState,
+//     condition: (x: RelationshipType) => boolean
+// ): boolean {
+//     const oldHg: Houseguest = getById(gameState, old.id);
+//     const newHg: Houseguest = getById(gameState, neww.id);
 
-    const oldPop = computeLocalPopularity(gameState, condition, hero, oldHg);
-    const newPop = computeLocalPopularity(gameState, condition, hero, newHg);
-    return oldPop < newPop;
-}
+//     const oldPop = computeLocalPopularity(gameState, condition, hero, oldHg);
+//     const newPop = computeLocalPopularity(gameState, condition, hero, newHg);
+//     return oldPop < newPop;
+// }
 
 function computeLocalPopularity(
     gameState: GameState,
@@ -199,89 +152,89 @@ export function computeEnemyCentrality(gameState: GameState, hero: Houseguest, v
     return computeLocalPopularity(gameState, underdogStrategy, hero, villian);
 }
 
-function isBetterTargetStatusQuo(
-    hero: Houseguest,
-    old: RelationshipSummary,
-    neww: RelationshipSummary,
-    winrateStrategy: WinrateStrategy,
-    gameState: GameState
-): NumberWithLogic {
-    if (winrateStrategy === WinrateStrategy.High || !inJury(gameState)) {
-        return voteBasedOnRelationship(hero, [old, neww]);
-    } else if (winrateStrategy === WinrateStrategy.Medium) {
-        // with a sort of low winrate, break ties with winrate
-        const r0 = classifyTwoWayRelationship(
-            hero.popularity,
-            old.villainPopularity,
-            hero.relationships[old.id]
-        );
-        const r1 = classifyTwoWayRelationship(
-            hero.popularity,
-            neww.villainPopularity,
-            hero.relationships[neww.id]
-        );
-        return r0 === r1
-            ? voteBasedonWinrate(hero, old, neww, voteBasedOnRelationship)
-            : voteBasedOnRelationship(hero, [old, neww]);
-    } else {
-        return voteBasedonWinrate(hero, old, neww, voteBasedOnRelationship);
-    }
-}
+// function isBetterTargetStatusQuo(
+//     hero: Houseguest,
+//     old: RelationshipSummary,
+//     neww: RelationshipSummary,
+//     winrateStrategy: WinrateStrategy,
+//     gameState: GameState
+// ): NumberWithLogic {
+//     if (winrateStrategy === WinrateStrategy.High || !inJury(gameState)) {
+//         return voteBasedOnRelationship(hero, [old, neww]);
+//     } else if (winrateStrategy === WinrateStrategy.Medium) {
+//         // with a sort of low winrate, break ties with winrate
+//         const r0 = classifyTwoWayRelationship(
+//             hero.popularity,
+//             old.villainPopularity,
+//             hero.relationships[old.id]
+//         );
+//         const r1 = classifyTwoWayRelationship(
+//             hero.popularity,
+//             neww.villainPopularity,
+//             hero.relationships[neww.id]
+//         );
+//         return r0 === r1
+//             ? voteBasedonWinrate(hero, old, neww, voteBasedOnRelationship)
+//             : voteBasedOnRelationship(hero, [old, neww]);
+//     } else {
+//         return voteBasedonWinrate(hero, old, neww, voteBasedOnRelationship);
+//     }
+// }
 
-function voteBasedonWinrate(
-    hero: Houseguest,
-    nom0: RelationshipSummary,
-    nom1: RelationshipSummary,
-    callback: (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]) => NumberWithLogic
-): NumberWithLogic {
-    const heroBeatsnom0 = hero.powerRanking < hero.superiors[nom0.id];
-    const heroBeatsnom1 = hero.powerRanking < hero.superiors[nom1.id];
-    // if i am voting between 2 people who i can't beat, vote based on callback
-    if (!heroBeatsnom0 && !heroBeatsnom1) {
-        return callback(hero, [nom0, nom1]);
-    }
-    // otherwise, vote based on winrate
-    const decision = hero.superiors[nom0.id] < hero.superiors[nom1.id] ? 0 : 1;
-    return {
-        decision,
-        reason: `I can't beat ${[nom0, nom1][decision].villianName} in the end.`,
-    };
-}
+// function voteBasedonWinrate(
+//     hero: Houseguest,
+//     nom0: RelationshipSummary,
+//     nom1: RelationshipSummary,
+//     callback: (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]) => NumberWithLogic
+// ): NumberWithLogic {
+//     const heroBeatsnom0 = hero.powerRanking < hero.superiors[nom0.id];
+//     const heroBeatsnom1 = hero.powerRanking < hero.superiors[nom1.id];
+//     // if i am voting between 2 people who i can't beat, vote based on callback
+//     if (!heroBeatsnom0 && !heroBeatsnom1) {
+//         return callback(hero, [nom0, nom1]);
+//     }
+//     // otherwise, vote based on winrate
+//     const decision = hero.superiors[nom0.id] < hero.superiors[nom1.id] ? 0 : 1;
+//     return {
+//         decision,
+//         reason: `I can't beat ${[nom0, nom1][decision].villianName} in the end.`,
+//     };
+// }
 
-// returns the index (0 or 1) of the vote
-// formerly known as cutthroatVote
-function voteBasedOnRelationship(
-    hero: Houseguest,
-    nominees: [RelationshipSummary, RelationshipSummary]
-): NumberWithLogic {
-    const nom0 = nominees[0];
-    const nom1 = nominees[1];
-    const r0 = classifyRelationship(hero.popularity, nom0.villainPopularity, hero.relationships[nom0.id]);
-    const r1 = classifyRelationship(hero.popularity, nom1.villainPopularity, hero.relationships[nom1.id]);
+// // returns the index (0 or 1) of the vote
+// // formerly known as cutthroatVote
+// function voteBasedOnRelationship(
+//     hero: Houseguest,
+//     nominees: [RelationshipSummary, RelationshipSummary]
+// ): NumberWithLogic {
+//     const nom0 = nominees[0];
+//     const nom1 = nominees[1];
+//     const r0 = classifyRelationship(hero.popularity, nom0.villainPopularity, hero.relationships[nom0.id]);
+//     const r1 = classifyRelationship(hero.popularity, nom1.villainPopularity, hero.relationships[nom1.id]);
 
-    if (r0 === RelationshipType.Enemy && r1 === RelationshipType.Enemy) {
-        const decision = hero.relationships[nom0.id] < hero.relationships[nom1.id] ? 0 : 1;
-        return {
-            decision,
-            reason: `I dislike ${nominees[decision].villianName} the most of these enemies.`,
-        };
-    } else if (
-        (r0 === RelationshipType.Enemy && r1 !== RelationshipType.Enemy) ||
-        (r1 === RelationshipType.Enemy && r0 !== RelationshipType.Enemy)
-    ) {
-        const vote = r0 === RelationshipType.Enemy ? 0 : 1;
-        return { decision: vote, reason: `${nominees[vote].villianName} is my enemy.` };
-    } else if (
-        (r0 !== RelationshipType.Friend && r1 === RelationshipType.Friend) ||
-        (r1 !== RelationshipType.Friend && r0 === RelationshipType.Friend)
-    ) {
-        const vote = r0 !== RelationshipType.Friend ? 0 : 1;
-        const nonVote = vote === 0 ? 1 : 0;
-        return { decision: vote, reason: `${nominees[nonVote].villianName} is my friend.` };
-    }
-    const vote = lowestScore(hero, nominees, relationship);
-    return {
-        decision: vote,
-        reason: `I like ${nominees[vote === 0 ? 1 : 0].villianName} the most of these noms.`,
-    };
-}
+//     if (r0 === RelationshipType.Enemy && r1 === RelationshipType.Enemy) {
+//         const decision = hero.relationships[nom0.id] < hero.relationships[nom1.id] ? 0 : 1;
+//         return {
+//             decision,
+//             reason: `I dislike ${nominees[decision].villianName} the most of these enemies.`,
+//         };
+//     } else if (
+//         (r0 === RelationshipType.Enemy && r1 !== RelationshipType.Enemy) ||
+//         (r1 === RelationshipType.Enemy && r0 !== RelationshipType.Enemy)
+//     ) {
+//         const vote = r0 === RelationshipType.Enemy ? 0 : 1;
+//         return { decision: vote, reason: `${nominees[vote].villianName} is my enemy.` };
+//     } else if (
+//         (r0 !== RelationshipType.Friend && r1 === RelationshipType.Friend) ||
+//         (r1 !== RelationshipType.Friend && r0 === RelationshipType.Friend)
+//     ) {
+//         const vote = r0 !== RelationshipType.Friend ? 0 : 1;
+//         const nonVote = vote === 0 ? 1 : 0;
+//         return { decision: vote, reason: `${nominees[nonVote].villianName} is my friend.` };
+//     }
+//     const vote = lowestScore(hero, nominees, relationship);
+//     return {
+//         decision: vote,
+//         reason: `I like ${nominees[vote === 0 ? 1 : 0].villianName} the most of these noms.`,
+//     };
+// }

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -21,7 +21,7 @@ export function selectTargetWithLogic(options: number[], hero: Houseguest, inten
     const badIntent = intent === "bad";
     const decide = badIntent ? mostDesiredTarget : leastDesiredTarget;
     const decision = decide(hero.hitList, new Set(options)).id;
-    const reason = generateExcuse(hero, decision, options, intent);
+    const reason = generateExcuse(hero, decision, intent);
     return { decision, reason };
 }
 
@@ -42,86 +42,6 @@ export function shouldKillNew(old: number, neww: number, hero: Houseguest): bool
     console.error(hero.hitList);
     throw new Error(`isBetterTarget: hitlist of ${hero} tried to find ${old} or ${neww} but couldn't`);
 }
-
-// function voteBasedOnCentrality(
-//     gameState: GameState,
-//     internalCallback: (x: RelationshipType) => boolean
-// ): (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]) => NumberWithLogic {
-//     return (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]): NumberWithLogic => {
-//         const decision = isMoreCentral(hero, nominees[0], nominees[1], gameState, internalCallback) ? 1 : 0;
-//         return {
-//             decision,
-//             reason: `${[nominees[0], nominees[1]][decision].villianName} is more popular among my enemies.`,
-//         };
-//     };
-// }
-
-// function targetNonfriends(
-//     hero: Houseguest,
-//     old: RelationshipSummary,
-//     neww: RelationshipSummary,
-//     callback: (
-//         hero: Houseguest,
-//         nominees: [RelationshipSummary, RelationshipSummary],
-//         callback?: (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]) => NumberWithLogic
-//     ) => NumberWithLogic
-// ): NumberWithLogic {
-//     if (old.type === RelationshipType.Friend) return _targetNonfriends();
-//     if (neww.type === RelationshipType.Friend)
-//         return { decision: 0, reason: `${old.villianName} is not my friend.` };
-//     return callback(hero, [old, neww]);
-
-//     function _targetNonfriends() {
-//         // runs if old is not an enemy -> runs if old is not an enemy or neutral
-//         const decision = (neww.type !== RelationshipType.Friend ? true : neww.relationship < old.relationship)
-//             ? 1
-//             : 0;
-//         return {
-//             decision,
-//             reason: `I like ${[old, neww][decision].villianName} the least of these noms.`,
-//         };
-//     }
-// }
-
-const underdogStrategy = (x: RelationshipType) => x !== RelationshipType.Friend;
-// function isBetterTargetUnderdog(
-//     old: RelationshipSummary,
-//     neww: RelationshipSummary,
-//     gameState: GameState,
-//     hero: Houseguest,
-//     winrateStrategy: WinrateStrategy
-// ): NumberWithLogic {
-//     if (winrateStrategy === WinrateStrategy.High || !inJury(gameState)) {
-//         // prioritize targeting enemies, break ties based on enemy centrality
-//         return targetNonfriends(hero, old, neww, voteBasedOnCentrality(gameState, underdogStrategy));
-//     } else if (winrateStrategy === WinrateStrategy.Medium) {
-//         // prioritize targeting enemies, break ties based on if i can beat them, then break further ties based on centrality
-//         return targetNonfriends(hero, old, neww, (hero, [old, neww]) =>
-//             voteBasedonWinrate(hero, old, neww, voteBasedOnCentrality(gameState, underdogStrategy))
-//         );
-//     } else {
-//         // prioritize targeting high winrate, break ties based on friend/enemy status, then centrality
-//         return voteBasedonWinrate(hero, old, neww, (hero, [old, neww]) =>
-//             targetNonfriends(hero, old, neww, voteBasedOnCentrality(gameState, underdogStrategy))
-//         );
-//     }
-// }
-
-// returns true if neww is more central than old
-// function isMoreCentral(
-//     hero: Houseguest,
-//     old: RelationshipSummary,
-//     neww: RelationshipSummary,
-//     gameState: GameState,
-//     condition: (x: RelationshipType) => boolean
-// ): boolean {
-//     const oldHg: Houseguest = getById(gameState, old.id);
-//     const newHg: Houseguest = getById(gameState, neww.id);
-
-//     const oldPop = computeLocalPopularity(gameState, condition, hero, oldHg);
-//     const newPop = computeLocalPopularity(gameState, condition, hero, newHg);
-//     return oldPop < newPop;
-// }
 
 function computeLocalPopularity(
     gameState: GameState,
@@ -149,92 +69,10 @@ function computeLocalPopularity(
 }
 
 export function computeEnemyCentrality(gameState: GameState, hero: Houseguest, villian: Houseguest): number {
-    return computeLocalPopularity(gameState, underdogStrategy, hero, villian);
+    return computeLocalPopularity(
+        gameState,
+        (x: RelationshipType) => x !== RelationshipType.Friend,
+        hero,
+        villian
+    );
 }
-
-// function isBetterTargetStatusQuo(
-//     hero: Houseguest,
-//     old: RelationshipSummary,
-//     neww: RelationshipSummary,
-//     winrateStrategy: WinrateStrategy,
-//     gameState: GameState
-// ): NumberWithLogic {
-//     if (winrateStrategy === WinrateStrategy.High || !inJury(gameState)) {
-//         return voteBasedOnRelationship(hero, [old, neww]);
-//     } else if (winrateStrategy === WinrateStrategy.Medium) {
-//         // with a sort of low winrate, break ties with winrate
-//         const r0 = classifyTwoWayRelationship(
-//             hero.popularity,
-//             old.villainPopularity,
-//             hero.relationships[old.id]
-//         );
-//         const r1 = classifyTwoWayRelationship(
-//             hero.popularity,
-//             neww.villainPopularity,
-//             hero.relationships[neww.id]
-//         );
-//         return r0 === r1
-//             ? voteBasedonWinrate(hero, old, neww, voteBasedOnRelationship)
-//             : voteBasedOnRelationship(hero, [old, neww]);
-//     } else {
-//         return voteBasedonWinrate(hero, old, neww, voteBasedOnRelationship);
-//     }
-// }
-
-// function voteBasedonWinrate(
-//     hero: Houseguest,
-//     nom0: RelationshipSummary,
-//     nom1: RelationshipSummary,
-//     callback: (hero: Houseguest, nominees: [RelationshipSummary, RelationshipSummary]) => NumberWithLogic
-// ): NumberWithLogic {
-//     const heroBeatsnom0 = hero.powerRanking < hero.superiors[nom0.id];
-//     const heroBeatsnom1 = hero.powerRanking < hero.superiors[nom1.id];
-//     // if i am voting between 2 people who i can't beat, vote based on callback
-//     if (!heroBeatsnom0 && !heroBeatsnom1) {
-//         return callback(hero, [nom0, nom1]);
-//     }
-//     // otherwise, vote based on winrate
-//     const decision = hero.superiors[nom0.id] < hero.superiors[nom1.id] ? 0 : 1;
-//     return {
-//         decision,
-//         reason: `I can't beat ${[nom0, nom1][decision].villianName} in the end.`,
-//     };
-// }
-
-// // returns the index (0 or 1) of the vote
-// // formerly known as cutthroatVote
-// function voteBasedOnRelationship(
-//     hero: Houseguest,
-//     nominees: [RelationshipSummary, RelationshipSummary]
-// ): NumberWithLogic {
-//     const nom0 = nominees[0];
-//     const nom1 = nominees[1];
-//     const r0 = classifyRelationship(hero.popularity, nom0.villainPopularity, hero.relationships[nom0.id]);
-//     const r1 = classifyRelationship(hero.popularity, nom1.villainPopularity, hero.relationships[nom1.id]);
-
-//     if (r0 === RelationshipType.Enemy && r1 === RelationshipType.Enemy) {
-//         const decision = hero.relationships[nom0.id] < hero.relationships[nom1.id] ? 0 : 1;
-//         return {
-//             decision,
-//             reason: `I dislike ${nominees[decision].villianName} the most of these enemies.`,
-//         };
-//     } else if (
-//         (r0 === RelationshipType.Enemy && r1 !== RelationshipType.Enemy) ||
-//         (r1 === RelationshipType.Enemy && r0 !== RelationshipType.Enemy)
-//     ) {
-//         const vote = r0 === RelationshipType.Enemy ? 0 : 1;
-//         return { decision: vote, reason: `${nominees[vote].villianName} is my enemy.` };
-//     } else if (
-//         (r0 !== RelationshipType.Friend && r1 === RelationshipType.Friend) ||
-//         (r1 !== RelationshipType.Friend && r0 === RelationshipType.Friend)
-//     ) {
-//         const vote = r0 !== RelationshipType.Friend ? 0 : 1;
-//         const nonVote = vote === 0 ? 1 : 0;
-//         return { decision: vote, reason: `${nominees[nonVote].villianName} is my friend.` };
-//     }
-//     const vote = lowestScore(hero, nominees, relationship);
-//     return {
-//         decision: vote,
-//         reason: `I like ${nominees[vote === 0 ? 1 : 0].villianName} the most of these noms.`,
-//     };
-// }

--- a/src/utils/ai/targets.ts
+++ b/src/utils/ai/targets.ts
@@ -1,9 +1,7 @@
-import { exclude, GameState, getById, Houseguest, inJury } from "../../model";
-import { backdoorNPlayers, NumberWithLogic } from "./aiApi";
+import { GameState, getById, Houseguest, inJury } from "../../model";
+import { NumberWithLogic } from "./aiApi";
 import { lowestScore, relationship } from "./aiUtils";
 import { classifyRelationship, classifyTwoWayRelationship, RelationshipType } from "./classifyRelationship";
-
-// abandon all hope ye who enter here
 
 interface RelationshipSummary {
     type: RelationshipType;
@@ -14,16 +12,6 @@ interface RelationshipSummary {
     villainPopularity: number;
     villianName: string;
 }
-
-const deadValue: RelationshipSummary = {
-    type: RelationshipType.Friend,
-    id: -123456789, // to make debugging easier :)
-    pHeroWins: -1,
-    winrate: -1,
-    relationship: 2,
-    villainPopularity: 2,
-    villianName: "This is an error",
-};
 
 export function getRelationshipSummary(hero: Houseguest, villain: Houseguest): RelationshipSummary {
     const doIWin = hero.superiors[villain.id];
@@ -37,27 +25,6 @@ export function getRelationshipSummary(hero: Houseguest, villain: Houseguest): R
         villainPopularity: villain.popularity,
         villianName: villain.name,
     };
-}
-
-export class Targets {
-    private firstTarget: RelationshipSummary = deadValue;
-    private secondTarget: RelationshipSummary = deadValue;
-    private hg: Houseguest;
-
-    constructor(hg: Houseguest) {
-        this.hg = hg;
-    }
-
-    public getTargets(): [number, number] {
-        return [this.firstTarget.id, this.secondTarget.id];
-    }
-    public refreshTargets(gameState: GameState, houseguests: Houseguest[]) {
-        const exclusion = exclude(houseguests, [this.hg]);
-        if (exclusion.length < 2) return;
-        const choices = backdoorNPlayers(this.hg, exclusion, gameState, 2);
-        this.firstTarget = getRelationshipSummary(this.hg, getById(gameState, choices[0].decision));
-        this.secondTarget = getRelationshipSummary(this.hg, getById(gameState, choices[1].decision));
-    }
 }
 
 export enum WinrateStrategy {

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -94,7 +94,6 @@ export function linear_transform(
 }
 
 // returns a value between 0 and pi
-
 export function angleBetween(x: number[], y: number[]): number {
     if (x.length !== y.length)
         throw new Error(

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -73,7 +73,7 @@ function dot(x: number[], y: number[]) {
     return result;
 }
 
-export function magnitude(x: number[]): number {
+function magnitude(x: number[]): number {
     let result = 0;
     x.forEach((x) => (result += x ** 2));
     return Math.sqrt(result);

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -83,6 +83,16 @@ export function magnitude(x: number[]): number {
     return Math.sqrt(result);
 }
 
+export function linear_transform(
+    x: number,
+    input_start: number,
+    input_end: number,
+    output_start: number,
+    output_end: number
+) {
+    return ((x - input_start) / (input_end - input_start)) * (output_end - output_start) + output_start;
+}
+
 // returns a value between 0 and pi
 
 export function angleBetween(x: number[], y: number[]): number {

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -18,10 +18,6 @@ export function roundTwoDigits(number: number | undefined) {
     return Math.round(number * 100);
 }
 
-export function max(a: number, b: number) {
-    return a > b ? a : b;
-}
-
 export function intersection<T>(setA: Set<T>, setB: Set<T>): Set<T> {
     let _intersection = new Set<T>();
     for (let elem of setB) {


### PR DESCRIPTION
__New Features:__

- New Twist: Big Brother Australia. A week with 3 nominees and no veto. Everyone but the HoH votes to evict one of the three nominees. (requested by @Dragonthud#9697, June 9th 2022)
- Improved veto AI, espescially for houseguests that have a low endgame winrate.
- Added tooltip clarifying that Co-HoHs will still play in veto over the HoH plays in veto option.

__Bugfixes:__

- Fixed a bug where the HoH does not play veto option would be ignored after editing relationships (reported by @᲼᲼᲼᲼᲼᲼᲼᲼᲼᲼᲼᲼᲼᲼#6737)
