### PR TITLE
Split improvements

### DIFF
--- a/src/components/episode/australiaEpisode.tsx
+++ b/src/components/episode/australiaEpisode.tsx
@@ -5,7 +5,6 @@ import { EpisodeType, Episode } from "./episodes";
 export const BbAustralia: EpisodeType = {
     canPlayWith: (n: number) => n >= 4,
     eliminates: 1,
-    arrowsEnabled: true,
     emoji: "🇦🇺",
     name: "BB Australia",
     description:

--- a/src/components/episode/australiaEpisode.tsx
+++ b/src/components/episode/australiaEpisode.tsx
@@ -7,7 +7,6 @@ export const BbAustralia: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: true,
     emoji: "🇦🇺",
-    hasViewsbar: true,
     name: "BB Australia",
     description:
         "3 nominees, and no veto. Nominees are able to vote. The previous HoH participates in the HoH comp.",

--- a/src/components/episode/australiaEpisode.tsx
+++ b/src/components/episode/australiaEpisode.tsx
@@ -9,7 +9,8 @@ export const BbAustralia: EpisodeType = {
     emoji: "🇦🇺",
     hasViewsbar: true,
     name: "BB Australia",
-    description: "3 nominees, and no veto. Nominees are able to vote.",
+    description:
+        "3 nominees, and no veto. Nominees are able to vote. The previous HoH participates in the HoH comp.",
     generate,
 };
 
@@ -18,6 +19,7 @@ function generate(initialGamestate: GameState): Episode {
         veto: null,
         thirdNominee: true,
         nomineesCanVote: true,
+        previousHoHcanCompete: true,
     });
     return new Episode({
         gameState: new GameState(episode.gameState),

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -86,6 +86,8 @@ interface BBVanillaOptions {
     previousHoHcanCompete?: boolean;
     coHoH?: boolean;
     coHohIsFinal?: boolean;
+    votingTo?: "Evict" | "Save";
+    hohCompCustomText?: string;
     tieBreaker?: (hg: Houseguest | undefined) => TieBreaker | undefined; // kind of a hack, might need to be updated later
 }
 
@@ -109,6 +111,7 @@ export function generateBBVanillaScenes(
         previousHoHcanCompete: options.previousHoHcanCompete,
         coHoH: options.coHoH,
         coHohIsFinal: options.coHohIsFinal,
+        customText: options.hohCompCustomText,
     });
     scenes.push(hohCompScene);
 
@@ -160,7 +163,7 @@ export function generateVetoScenesOnwards(
     let evictionScene;
     [currentGameState, evictionScene] = generateEvictionScene(currentGameState, hohArray, nominees, {
         doubleEviction,
-        votingTo: "Evict",
+        votingTo: options.votingTo || "Evict",
         splitIndex,
         nomineesCanVote: options.nomineesCanVote,
         tieBreaker: options.tieBreaker && options.tieBreaker(povWinner),

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -83,6 +83,7 @@ interface BBVanillaOptions {
     splitIndex?: number;
     nomineesCanVote?: boolean;
     thirdNominee?: boolean;
+    previousHoHcanCompete?: boolean;
 }
 
 export function generateBBVanillaScenes(
@@ -102,6 +103,7 @@ export function generateBBVanillaScenes(
     [currentGameState, hohCompScene, hohArray] = generateHohCompScene(initialGamestate, {
         doubleEviction,
         splitIndex,
+        previousHoHcanCompete: options.previousHoHcanCompete,
     });
     const hoh = hohArray[0];
     scenes.push(hohCompScene);

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -18,7 +18,6 @@ export const BigBrotherVanilla: EpisodeType = {
         return n > 3;
     },
     eliminates: 1,
-    arrowsEnabled: true,
     name: "",
     emoji: "",
     description: "",

--- a/src/components/episode/bigBrotherEpisode.tsx
+++ b/src/components/episode/bigBrotherEpisode.tsx
@@ -19,7 +19,6 @@ export const BigBrotherVanilla: EpisodeType = {
     },
     eliminates: 1,
     arrowsEnabled: true,
-    hasViewsbar: true,
     name: "",
     emoji: "",
     description: "",

--- a/src/components/episode/bigBrotherFinale.tsx
+++ b/src/components/episode/bigBrotherFinale.tsx
@@ -12,7 +12,6 @@ export const BigBrotherFinale: EpisodeType = {
     canPlayWith: (n: number) => n === 3,
     eliminates: 2,
     arrowsEnabled: true,
-    hasViewsbar: true,
     generate: generateBbFinale,
 };
 

--- a/src/components/episode/bigBrotherFinale.tsx
+++ b/src/components/episode/bigBrotherFinale.tsx
@@ -11,7 +11,6 @@ import { HasText } from "../layout/text";
 export const BigBrotherFinale: EpisodeType = {
     canPlayWith: (n: number) => n === 3,
     eliminates: 2,
-    arrowsEnabled: true,
     generate: generateBbFinale,
 };
 

--- a/src/components/episode/boomerangVetoEpisode.tsx
+++ b/src/components/episode/boomerangVetoEpisode.tsx
@@ -6,7 +6,6 @@ import { BoomerangVeto } from "./veto/veto";
 export const BoomerangVetoEpisode: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
     eliminates: 1,
-    arrowsEnabled: true,
     emoji: "🪃",
     description: "A veto that must be discarded or used to save both nominees.",
     name: "Boomerang Veto",

--- a/src/components/episode/boomerangVetoEpisode.tsx
+++ b/src/components/episode/boomerangVetoEpisode.tsx
@@ -7,7 +7,6 @@ export const BoomerangVetoEpisode: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
     eliminates: 1,
     arrowsEnabled: true,
-    hasViewsbar: true,
     emoji: "🪃",
     description: "A veto that must be discarded or used to save both nominees.",
     name: "Boomerang Veto",

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -12,7 +12,6 @@ export const BattleOfTheBlock: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: true,
     emoji: "⚔️",
-    hasViewsbar: true,
     name: "Battle of the Block",
     description:
         "Two HoHs name a total of four nominees. The nominees compete in a competition, and the winners are safe for the week and dethrone the HoH who nominated them.",

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -52,9 +52,16 @@ function generateBoB(initialGamestate: GameState): Episode {
     scenes.push(botbscene);
     // then veto onwards plays normally except
     // the winning pair is somehow immune for the week: they can't be backdoored.
-    const vetostuff = generateVetoScenesOnwards(currentGameState, finalhoh, finalnoms, scenes, botbWinners, {
-        veto: GoldenVeto,
-    });
+    const vetostuff = generateVetoScenesOnwards(
+        currentGameState,
+        [finalhoh],
+        finalnoms,
+        scenes,
+        botbWinners,
+        {
+            veto: GoldenVeto,
+        }
+    );
     currentGameState = vetostuff.gameState;
 
     return new Episode({

--- a/src/components/episode/botbEpisode.tsx
+++ b/src/components/episode/botbEpisode.tsx
@@ -10,7 +10,6 @@ import { generateBotbScene } from "./scenes/botbScene";
 export const BattleOfTheBlock: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
     eliminates: 1,
-    arrowsEnabled: true,
     emoji: "⚔️",
     name: "Battle of the Block",
     description:

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -7,7 +7,6 @@ import { generateBBVanillaScenes } from "./bigBrotherEpisode";
 export const CoHoH: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
     eliminates: 1,
-    arrowsEnabled: true,
     name: "Co-HoH",
     description:
         "Two HoHs each name one nominee, and are responsible for replacing the person they nominated if the veto is used on them.",

--- a/src/components/episode/coHoHEpisode.tsx
+++ b/src/components/episode/coHoHEpisode.tsx
@@ -8,7 +8,6 @@ export const CoHoH: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
     eliminates: 1,
     arrowsEnabled: true,
-    hasViewsbar: true,
     name: "Co-HoH",
     description:
         "Two HoHs each name one nominee, and are responsible for replacing the person they nominated if the veto is used on them.",

--- a/src/components/episode/diamondVetoEpisode.tsx
+++ b/src/components/episode/diamondVetoEpisode.tsx
@@ -8,7 +8,6 @@ export const DiamondVetoEpisode: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: true,
     emoji: "💎",
-    hasViewsbar: true,
     name: "Diamond Veto",
     description: "The veto winner has the right to name a replacement nominee.",
     generate,

--- a/src/components/episode/diamondVetoEpisode.tsx
+++ b/src/components/episode/diamondVetoEpisode.tsx
@@ -6,7 +6,6 @@ import { DiamondVeto } from "./veto/veto";
 export const DiamondVetoEpisode: EpisodeType = {
     canPlayWith: (n: number) => n >= 4,
     eliminates: 1,
-    arrowsEnabled: true,
     emoji: "💎",
     name: "Diamond Veto",
     description: "The veto winner has the right to name a replacement nominee.",

--- a/src/components/episode/doubleEvictionEpisode.tsx
+++ b/src/components/episode/doubleEvictionEpisode.tsx
@@ -8,7 +8,6 @@ import { GoldenVeto } from "./veto/veto";
 export const DoubleEviction: EpisodeType = {
     canPlayWith: (n: number) => n >= 4,
     eliminates: 1,
-    arrowsEnabled: true,
     emoji: "⏩",
     chainable: true,
     name: "Double Eviction",

--- a/src/components/episode/doubleEvictionEpisode.tsx
+++ b/src/components/episode/doubleEvictionEpisode.tsx
@@ -10,7 +10,6 @@ export const DoubleEviction: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: true,
     emoji: "⏩",
-    hasViewsbar: true,
     chainable: true,
     name: "Double Eviction",
     description: "A second round of Big Brother plays out in a single scene.",

--- a/src/components/episode/episodeFactory.ts
+++ b/src/components/episode/episodeFactory.ts
@@ -3,7 +3,6 @@ import { Episode, Houseguest } from "../../model";
 import { EpisodeType, Split } from "./episodes";
 import { angleBetween, rng } from "../../utils";
 import { EpisodeLog } from "../../model/logging/episodelog";
-import { generateCliques } from "../../utils/generateCliques";
 import { refreshHgStats } from "./utilities/evictHouseguest";
 import { cast$ } from "../../subjects/subjects";
 
@@ -68,7 +67,6 @@ export function nextEpisode(oldState: GameState, episodeType: EpisodeType): Epis
     nonEvictedHouseguests(newState).forEach((hg) => {
         hg.previousPopularity = hg.popularity;
     });
-    newState.cliques = generateCliques(newState);
     const finalState = new GameState(newState);
 
     if (!episodeType.canPlayWith(finalState.remainingPlayers))

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -66,6 +66,13 @@ export function getSplitMembers(split: { members: Set<number> }, gameState: Game
     return Array.from(split.members).map((id) => getById(gameState, id));
 }
 
+export function getNonevictedSplitMembers(
+    split: { members: Set<number> },
+    gameState: GameState
+): Houseguest[] {
+    return getSplitMembers(split, gameState).filter((hg) => !hg.isEvicted);
+}
+
 export interface EpisodeType {
     readonly canPlayWith: (n: number) => boolean;
     readonly eliminates: number;

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -24,7 +24,7 @@ export class Episode {
     readonly initialGameState: GameState;
     readonly type: EpisodeType;
     get render(): JSX.Element {
-        const viewsBar = this.type.hasViewsbar ? <ViewsBar gameState={this.scenes[0].gameState} /> : null;
+        const viewsBar = this.type.hideViewsBar ? null : <ViewsBar gameState={this.scenes[0].gameState} />;
         return (
             <div>
                 {viewsBar}
@@ -77,7 +77,7 @@ export interface EpisodeType {
     readonly canPlayWith: (n: number) => boolean;
     readonly eliminates: number;
     readonly arrowsEnabled?: boolean;
-    readonly hasViewsbar?: boolean;
+    readonly hideViewsBar?: boolean;
     readonly chainable?: boolean;
     readonly pseudo?: boolean;
     readonly name?: string;

--- a/src/components/episode/episodes.tsx
+++ b/src/components/episode/episodes.tsx
@@ -76,7 +76,7 @@ export function getNonevictedSplitMembers(
 export interface EpisodeType {
     readonly canPlayWith: (n: number) => boolean;
     readonly eliminates: number;
-    readonly arrowsEnabled?: boolean;
+    readonly arrowsDisabled?: boolean;
     readonly hideViewsBar?: boolean;
     readonly chainable?: boolean;
     readonly pseudo?: boolean;

--- a/src/components/episode/forcedVetoEpisode.tsx
+++ b/src/components/episode/forcedVetoEpisode.tsx
@@ -8,7 +8,6 @@ export const ForcedVetoEpisode: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: true,
     emoji: "🔦",
-    hasViewsbar: true,
     name: "Forced Veto",
     description: "The veto winner must use the veto.",
     generate: generateForcedVeto,

--- a/src/components/episode/forcedVetoEpisode.tsx
+++ b/src/components/episode/forcedVetoEpisode.tsx
@@ -6,7 +6,6 @@ import { SpotlightVeto } from "./veto/veto";
 export const ForcedVetoEpisode: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
     eliminates: 1,
-    arrowsEnabled: true,
     emoji: "🔦",
     name: "Forced Veto",
     description: "The veto winner must use the veto.",

--- a/src/components/episode/gameOver.tsx
+++ b/src/components/episode/gameOver.tsx
@@ -8,7 +8,7 @@ export const GameOver: EpisodeType = {
     canPlayWith: (_: number) => true,
     eliminates: 1,
     arrowsEnabled: false,
-    hasViewsbar: false,
+    hideViewsBar: true,
     description: "",
     emoji: "",
     name: "Game Over",

--- a/src/components/episode/gameOver.tsx
+++ b/src/components/episode/gameOver.tsx
@@ -7,7 +7,7 @@ import { evictHouseguest } from "./utilities/evictHouseguest";
 export const GameOver: EpisodeType = {
     canPlayWith: (_: number) => true,
     eliminates: 1,
-    arrowsEnabled: false,
+    arrowsDisabled: true,
     hideViewsBar: true,
     description: "",
     emoji: "",

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -9,7 +9,6 @@ export const InstantEviction: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: true,
     emoji: "⚡",
-    hasViewsbar: true,
     chainable: true,
     name: "Instant Eviction",
     description: "A double eviction without a veto.",

--- a/src/components/episode/instantEvictionEpisode.tsx
+++ b/src/components/episode/instantEvictionEpisode.tsx
@@ -7,7 +7,6 @@ import { Scene } from "./scenes/scene";
 export const InstantEviction: EpisodeType = {
     canPlayWith: (n: number) => n >= 4,
     eliminates: 1,
-    arrowsEnabled: true,
     emoji: "⚡",
     chainable: true,
     name: "Instant Eviction",

--- a/src/components/episode/noVetoEpisode.tsx
+++ b/src/components/episode/noVetoEpisode.tsx
@@ -7,7 +7,6 @@ export const NoVeto: EpisodeType = {
     eliminates: 1,
     arrowsEnabled: true,
     emoji: "🚫",
-    hasViewsbar: true,
     name: "No Veto",
     description: "A week without a veto.",
     generate: generateNoVeto,

--- a/src/components/episode/noVetoEpisode.tsx
+++ b/src/components/episode/noVetoEpisode.tsx
@@ -5,7 +5,6 @@ import { EpisodeType, Episode } from "./episodes";
 export const NoVeto: EpisodeType = {
     canPlayWith: (n: number) => n >= 4,
     eliminates: 1,
-    arrowsEnabled: true,
     emoji: "🚫",
     name: "No Veto",
     description: "A week without a veto.",

--- a/src/components/episode/pregameEpisode.tsx
+++ b/src/components/episode/pregameEpisode.tsx
@@ -8,7 +8,6 @@ const PregameEpisodeType: EpisodeType = {
     canPlayWith: (n: number) => {
         return n > 2;
     },
-    arrowsEnabled: true,
     emoji: "",
     hideViewsBar: true,
     name: "Pregame",

--- a/src/components/episode/pregameEpisode.tsx
+++ b/src/components/episode/pregameEpisode.tsx
@@ -10,7 +10,7 @@ const PregameEpisodeType: EpisodeType = {
     },
     arrowsEnabled: true,
     emoji: "",
-    hasViewsbar: false,
+    hideViewsBar: true,
     name: "Pregame",
     description: "",
     generate: (gameState: GameState) => new PregameEpisode(gameState),

--- a/src/components/episode/safetyChain.tsx
+++ b/src/components/episode/safetyChain.tsx
@@ -6,7 +6,6 @@ export const SafetyChain: EpisodeType = {
     canPlayWith: (n: number) => n >= 3,
     eliminates: 1,
     chainable: true,
-    arrowsEnabled: true,
     name: "Safety Chain",
     emoji: "⛓️",
     description:

--- a/src/components/episode/safetyChain.tsx
+++ b/src/components/episode/safetyChain.tsx
@@ -7,7 +7,6 @@ export const SafetyChain: EpisodeType = {
     eliminates: 1,
     chainable: true,
     arrowsEnabled: true,
-    hasViewsbar: true,
     name: "Safety Chain",
     emoji: "⛓️",
     description:

--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -23,7 +23,7 @@ function getHighestIndicies(numbers: number[]): number[] {
     return highestIndicies;
 }
 
-interface TieBreaker {
+export interface TieBreaker {
     hg: Houseguest;
     text: string;
     voteType: (id: number) => VoteType;

--- a/src/components/episode/splitHouse.tsx
+++ b/src/components/episode/splitHouse.tsx
@@ -1,5 +1,5 @@
 import { GameState, MutableGameState } from "../../model";
-import { generateBBVanillaScenes } from "./bigBrotherEpisode";
+import { defaultContent, generateBBVanillaScenes } from "./bigBrotherEpisode";
 import { Episode, EpisodeType, nonEvictedHousguestsSplit, Split } from "./episodes";
 import { Scene } from "./scenes/scene";
 import { GoldenVeto } from "./veto/veto";
@@ -38,6 +38,14 @@ function generate(initialGamestate: GameState): Episode {
     nonEvictedHousguestsSplit(0, currentGameState).forEach((hg) => {
         currentGameState.currentLog.votes[hg.id] = new BlankVote();
     });
+
+    const intermissionScene = new Scene({
+        title: "[Outdoors]",
+        content: defaultContent(currentGameState),
+        gameState: currentGameState,
+    });
+    scenes.push(intermissionScene);
+
     const split1 = generateBBVanillaScenes(currentGameState, {
         veto: GoldenVeto,
         splitIndex: 1,

--- a/src/components/episode/splitHouse.tsx
+++ b/src/components/episode/splitHouse.tsx
@@ -12,7 +12,6 @@ export const SplitHouse: EpisodeType = {
     eliminates: 2,
     arrowsEnabled: true,
     emoji: "↔️",
-    hasViewsbar: true,
     name: "Split House",
     description:
         "Houseguests are divided into two groups, and each group plays a round of Big Brother, isolated from the others.",
@@ -25,7 +24,6 @@ export const PersistentSplitHouse: EpisodeType = {
     eliminates: 2,
     arrowsEnabled: true,
     emoji: "↔️*",
-    hasViewsbar: true,
     name: "Persistent Split House",
     description: "A split house that uses the same split as the last week.",
     splitFunction: useLastSplit,

--- a/src/components/episode/splitHouse.tsx
+++ b/src/components/episode/splitHouse.tsx
@@ -10,7 +10,6 @@ import { BlankVote } from "../../model/logging/voteType";
 export const SplitHouse: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
     eliminates: 2,
-    arrowsEnabled: true,
     emoji: "↔️",
     name: "Split House",
     description:
@@ -22,7 +21,6 @@ export const SplitHouse: EpisodeType = {
 export const PersistentSplitHouse: EpisodeType = {
     canPlayWith: (n: number) => n >= 6,
     eliminates: 2,
-    arrowsEnabled: true,
     emoji: "↔️*",
     name: "Persistent Split House",
     description: "A split house that uses the same split as the last week.",

--- a/src/components/episode/splitHouse.tsx
+++ b/src/components/episode/splitHouse.tsx
@@ -20,6 +20,18 @@ export const SplitHouse: EpisodeType = {
     generate,
 };
 
+export const PersistentSplitHouse: EpisodeType = {
+    canPlayWith: (n: number) => n >= 6,
+    eliminates: 2,
+    arrowsEnabled: true,
+    emoji: "↔️*",
+    hasViewsbar: true,
+    name: "Persistent Split House",
+    description: "A split house that uses the same split as the last week.",
+    splitFunction: useLastSplit,
+    generate,
+};
+
 function generate(initialGamestate: GameState): Episode {
     let currentGameState = new MutableGameState(initialGamestate);
     const scenes: Scene[] = [];
@@ -59,6 +71,12 @@ function generate(initialGamestate: GameState): Episode {
         scenes,
         type: SplitHouse,
     });
+}
+
+function useLastSplit(gameState: GameState): Split[] {
+    return gameState.split.length > 0
+        ? gameState.split
+        : splitHouseRandomly(["Indoors", "Outdoors"])(gameState);
 }
 
 function splitHouseRandomly(names: string[]): (gameState: GameState) => Split[] {

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -7,7 +7,6 @@ import { generateBBVanillaScenes } from "./bigBrotherEpisode";
 export const TripleEvictionCad: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
     eliminates: 2,
-    arrowsEnabled: true,
     emoji: "🇨🇦",
     chainable: true,
     name: "Triple Eviction",

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -10,7 +10,6 @@ export const TripleEvictionCad: EpisodeType = {
     arrowsEnabled: true,
     emoji: "🇨🇦",
     chainable: true,
-    hasViewsbar: true,
     name: "Triple Eviction",
     description:
         "A double eviction with three nominees. Houseguests vote to save one, and the other two are evicted.",

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -1,12 +1,8 @@
-import { Episode, EpisodeType, GameState, Houseguest, MutableGameState } from "../../model";
+import { Episode, EpisodeType, GameState, MutableGameState } from "../../model";
 import React from "react";
 import { Scene } from "./scenes/scene";
-import { generateHohCompScene } from "./scenes/hohCompScene";
-import { generateNomCeremonyScene } from "./scenes/nomCeremonyScene";
-import { generateVetoCompScene } from "./scenes/vetoCompScene";
-import { generateVetoCeremonyScene } from "./scenes/vetoCeremonyScene";
-import { generateEvictionScene } from "./scenes/evictionScene";
 import { GoldenVeto } from "./veto/veto";
+import { generateBBVanillaScenes } from "./bigBrotherEpisode";
 
 export const TripleEvictionCad: EpisodeType = {
     canPlayWith: (n: number) => n >= 5,
@@ -24,62 +20,24 @@ export const TripleEvictionCad: EpisodeType = {
 export function generateTripleEvictionCad(initialGamestate: GameState): Episode {
     let currentGameState = new MutableGameState(initialGamestate);
     const scenes: Scene[] = [];
-    const doubleEviction = true;
-
     currentGameState.incrementLogIndex();
 
-    let hohArray: Houseguest[];
-    let hohCompScene: Scene;
-    const tripleScenes: Scene[] = [];
-    [currentGameState, hohCompScene, hohArray] = generateHohCompScene(currentGameState, {
-        doubleEviction,
-        customText: "Houseguests, please return to the living room. Tonight will be a triple eviction.",
-    });
-    tripleScenes.push(hohCompScene);
-    const hoh = hohArray[0];
-
-    let nomCeremonyScene;
-    let nominees: Houseguest[];
-    [currentGameState, nomCeremonyScene, nominees] = generateNomCeremonyScene(currentGameState, [hoh], {
-        doubleEviction,
-        thirdNominee: true,
-    });
-    tripleScenes.push(nomCeremonyScene);
-
-    let vetoCompScene;
-    let povWinner: Houseguest;
-    [currentGameState, vetoCompScene, povWinner] = generateVetoCompScene(currentGameState, [hoh], nominees, {
+    const episode = generateBBVanillaScenes(currentGameState, {
         veto: GoldenVeto,
-        doubleEviction,
-    });
-    tripleScenes.push(vetoCompScene);
-
-    let vetoCeremonyScene;
-
-    [currentGameState, vetoCeremonyScene, nominees] = generateVetoCeremonyScene(
-        currentGameState,
-        [hoh],
-        nominees,
-        povWinner,
-        { doubleEviction, veto: GoldenVeto }
-    );
-    tripleScenes.push(vetoCeremonyScene);
-
-    let evictionScene;
-    [currentGameState, evictionScene] = generateEvictionScene(currentGameState, [hoh], nominees, {
-        doubleEviction,
+        doubleEviction: true,
+        thirdNominee: true,
         votingTo: "Save",
+        hohCompCustomText:
+            "Houseguests, please return to the living room. Tonight will be a triple eviction.",
     });
-    tripleScenes.push(evictionScene);
-
+    currentGameState = episode.gameState;
     scenes.push(
         new Scene({
             title: "Triple Eviction",
-            content: <div>{tripleScenes.map((scene) => scene.content)}</div>,
+            content: <div>{episode.scenes.map((scene) => scene.content)}</div>,
             gameState: currentGameState,
         })
     );
-
     return new Episode({
         gameState: new GameState(currentGameState),
         initialGamestate,

--- a/src/components/episode/utilities/evictHouseguest.ts
+++ b/src/components/episode/utilities/evictHouseguest.ts
@@ -8,13 +8,14 @@ import {
     getJurors,
     inJury,
     MutableGameState,
-    getSplitMembers,
+    getNonevictedSplitMembers,
 } from "../../../model";
 import { getFinalists } from "../../../model/season";
 import { average, roundTwoDigits } from "../../../utils";
 import { pHeroWinsTheFinale } from "../../../utils/ai/aiUtils";
 import { classifyRelationship, RelationshipType } from "../../../utils/ai/classifyRelationship";
 import { generateHitList } from "../../../utils/ai/hitList";
+import { generateCliques } from "../../../utils/generateCliques";
 
 export function evictHouseguest(gameState: MutableGameState, id: number): GameState {
     const evictee = getById(gameState, id);
@@ -46,10 +47,11 @@ export function refreshHgStats(
             ? split
             : [{ members: new Set<number>(nonEvictedHouseguests(gameState).map((hg) => hg.id)) }];
     splits.forEach((split) => {
-        const hgs = getSplitMembers(split, gameState);
+        const hgs = getNonevictedSplitMembers(split, gameState);
         updatePopularity(hgs, updateDelta);
         updateFriendCounts(hgs, gameState);
     });
+    gameState.cliques = generateCliques(gameState);
 }
 
 function populateSuperiors(houseguests: Houseguest[]) {

--- a/src/components/episode/utilities/evictHouseguest.ts
+++ b/src/components/episode/utilities/evictHouseguest.ts
@@ -104,9 +104,11 @@ function updateFriendCounts(houseguests: Houseguest[], gameState: GameState) {
         hero.enemies = enemies;
         const hitList = generateHitList(hero, gameState);
         hero.hitList = hitList;
+        const hgSet = new Set(houseguests.map((hg) => hg.id));
+        const hitListbySplit = hero.hitList.filter((entry) => hgSet.has(entry.id));
         const targets = [];
-        hero.hitList[0] && targets.push(hero.hitList[0].id);
-        hero.hitList[1] && targets.push(hero.hitList[1].id);
+        hitListbySplit[0] && targets.push(hitListbySplit[0].id);
+        hitListbySplit[1] && targets.push(hitListbySplit[1].id);
         targets.forEach((target) => {
             getById(gameState, target).targetingMe++;
         });

--- a/src/components/seasonEditor/getEpisodeLibrary.tsx
+++ b/src/components/seasonEditor/getEpisodeLibrary.tsx
@@ -199,7 +199,7 @@ export function getEpisodeLibrary(): EpisodeLibrary {
                 canPlayWith: () => true,
                 splitFunction: oldEpisode.splitFunction,
                 eliminates: oldEpisode.eliminates + newEpisode.eliminates,
-                hasViewsbar: oldEpisode.hasViewsbar || newEpisode.hasViewsbar,
+                hideViewsBar: oldEpisode.hideViewsBar || newEpisode.hideViewsBar,
                 emoji: `${oldEpisode.emoji} ${newEpisode.emoji}`,
             };
             const newItem: EpisodeType = {

--- a/src/components/seasonEditor/getEpisodeLibrary.tsx
+++ b/src/components/seasonEditor/getEpisodeLibrary.tsx
@@ -195,7 +195,7 @@ export function getEpisodeLibrary(): EpisodeLibrary {
             const oldEpisode = episodes[episodes.length - 1];
             const newEpisode = item.episode;
             const dynamicEpisodeType = {
-                arrowsEnabled: oldEpisode.arrowsEnabled || newEpisode.arrowsEnabled,
+                arrowsDisabled: oldEpisode.arrowsDisabled || newEpisode.arrowsDisabled,
                 canPlayWith: () => true,
                 splitFunction: oldEpisode.splitFunction,
                 eliminates: oldEpisode.eliminates + newEpisode.eliminates,

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -25,7 +25,7 @@ import { TwistAdder } from "./twistAdder";
 import { SafetyChain } from "../episode/safetyChain";
 import { getTeamsListContents, TeamsAdderList } from "./teamsAdderList";
 import { Tribe } from "../../model/tribe";
-import { SplitHouse } from "../episode/splitHouse";
+import { PersistentSplitHouse, SplitHouse } from "../episode/splitHouse";
 import { Tooltip } from "../tooltip/tooltip";
 import { BbAustralia } from "../episode/australiaEpisode";
 
@@ -50,6 +50,7 @@ const twists: EpisodeType[] = [
     CoHoH,
     BattleOfTheBlock,
     SplitHouse,
+    PersistentSplitHouse,
     BbAustralia,
 ];
 

--- a/src/components/sidebar/sidebarController.ts
+++ b/src/components/sidebar/sidebarController.ts
@@ -107,7 +107,7 @@ export class SidebarController {
         const state = this.view.state;
         if (
             state.episodes[this.selectedEpisode] === undefined ||
-            !state.episodes[this.selectedEpisode].type.arrowsEnabled ||
+            state.episodes[this.selectedEpisode].type.arrowsDisabled ||
             activeScreen$.value !== Screens.Ingame
         ) {
             return;

--- a/src/utils/generateCliques.ts
+++ b/src/utils/generateCliques.ts
@@ -1,5 +1,5 @@
 import { intersection } from ".";
-import { GameState, Split, getById, getNonevictedSplitMembers, nonEvictedHouseguests } from "../model";
+import { GameState, getById, getNonevictedSplitMembers, nonEvictedHouseguests } from "../model";
 import generateGraph from "./generateGraph";
 import { difference } from "./utilities";
 

--- a/src/utils/generateCliques.ts
+++ b/src/utils/generateCliques.ts
@@ -1,5 +1,5 @@
 import { intersection } from ".";
-import { GameState, getById, getSplitMembers, nonEvictedHouseguests } from "../model";
+import { GameState, Split, getById, getNonevictedSplitMembers, nonEvictedHouseguests } from "../model";
 import generateGraph from "./generateGraph";
 import { difference } from "./utilities";
 
@@ -25,7 +25,7 @@ export function generateCliques(gameState: GameState): Cliques[][] {
             generateCliquesFromGraph(gameState, generateGraph(gameState, nonEvictedHouseguests(gameState))),
         ];
     gameState.split.forEach((split) => {
-        const g = generateGraph(gameState, getSplitMembers(split, gameState));
+        const g = generateGraph(gameState, getNonevictedSplitMembers(split, gameState));
         result.push(generateCliquesFromGraph(gameState, g));
     });
     return result;


### PR DESCRIPTION
__New Features:__

- Persistent Split House: A split house twist that keeps the same split as last week.
- Split house twists now have an intermission episode after the first eviction that lets you see the house status.
- The previous HoH competes in the HoH competition in Australia episodes. 

__Bugfixes:__

- Fixed a bug where not all targets were being displayed in split houses.