### PR TITLE
Add persistent twist editor + bugfixes

### DIFF
--- a/src/components/episode/scenes/evictionScene.tsx
+++ b/src/components/episode/scenes/evictionScene.tsx
@@ -151,6 +151,7 @@ export function generateEvictionScene(
 
     evictees.forEach((evictee) => {
         newGameState = evictHouseguest(newGameState, evictee.id);
+        evictee.isJury = getById(newGameState, evictee.id).isJury;
     });
     const isUnanimous = voteCounts.filter((n) => n !== 0).length === 1;
     const voteCountText = isUnanimous

--- a/src/components/episode/tripleEvictionEpisodeCad.tsx
+++ b/src/components/episode/tripleEvictionEpisodeCad.tsx
@@ -33,7 +33,7 @@ export function generateTripleEvictionCad(initialGamestate: GameState): Episode 
         new Scene({
             title: "Triple Eviction",
             content: <div>{episode.scenes.map((scene) => scene.content)}</div>,
-            gameState: currentGameState,
+            gameState: initialGamestate,
         })
     );
     return new Episode({

--- a/src/components/playerPortrait/houseguestPortrait.tsx
+++ b/src/components/playerPortrait/houseguestPortrait.tsx
@@ -179,7 +179,7 @@ export class HouseguestPortrait extends React.Component<PortraitProps, PortraitS
             ? { backgroundColor: props.tribe.color, color: textColor(props.tribe.color) }
             : {};
         let Portrait = MemoryWallPortrait;
-        if (props.isJury) {
+        if (props.isJury && props.isEvicted) {
             Portrait = Jury;
             tribeStyle = {
                 backgroundColor: "#5d5340",
@@ -232,6 +232,6 @@ const TribeStyle = styled.div`
 
 function getImageClass(props: PortraitProps) {
     let imageClass = props.isEvicted ? Grayscale : Normal;
-    imageClass = props.isJury ? Sepia : imageClass;
+    imageClass = props.isJury && props.isEvicted ? Sepia : imageClass;
     return imageClass;
 }

--- a/src/components/seasonEditor/getEpisodeLibrary.tsx
+++ b/src/components/seasonEditor/getEpisodeLibrary.tsx
@@ -9,6 +9,7 @@ import { hasLogBeenModified } from "../../model/logging/episodelog";
 import { TeamAdderProps } from "./teamsAdder";
 import { _items, deleteTeams, _castSize } from "./seasonEditorList";
 import { isNotWellDefined } from "../../utils";
+import _ from "lodash";
 
 export function getEpisodeLibrary(): EpisodeLibrary {
     const generate = (_: any) => {
@@ -19,7 +20,7 @@ export function getEpisodeLibrary(): EpisodeLibrary {
     // generate teams
     let finalX = _castSize;
     const teamIdtoFinalX = new Map<number, number>();
-    const _mappedItems = _items.map((item) => {
+    const _mappedItems = _.cloneDeep(_items).map((item) => {
         if (item.episode.teamsLookupId !== undefined) {
             // if a team ends when it starts, don't use it FIXME: this will break 10000% when returnees happen
             // eslint-disable-next-line

--- a/src/components/seasonEditor/getEpisodeLibrary.tsx
+++ b/src/components/seasonEditor/getEpisodeLibrary.tsx
@@ -207,8 +207,10 @@ export function getEpisodeLibrary(): EpisodeLibrary {
                 generate: (initialGamestate) => {
                     const firstEpisode = oldEpisode.generate(initialGamestate);
                     const secondEpisode = newEpisode.generate(firstEpisode.gameState);
+                    const finalGameState = new GameState(secondEpisode.gameState);
+                    finalGameState.split = []; // FIXME: to prevent persistent split houses from breaking, chainable episodes reset splits
                     return new Episode({
-                        gameState: new GameState(secondEpisode.gameState),
+                        gameState: finalGameState,
                         // extremely important: pseudo stuff like teams happens in the initial gamestate
                         initialGamestate: firstEpisode.initialGameState,
                         scenes: firstEpisode.scenes.concat(secondEpisode.scenes),

--- a/src/components/seasonEditor/seasonEditorList.tsx
+++ b/src/components/seasonEditor/seasonEditorList.tsx
@@ -9,6 +9,7 @@ import { getEmoji, twist$ } from "./twistAdder";
 import { min } from "lodash";
 import { removeFirstNMatching, removeLast1Matching } from "../../utils";
 import { GameState, getById } from "../../model/gameState";
+import _ from "lodash";
 
 const common = `
 padding: 10px;
@@ -163,10 +164,10 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
             const newItem = {
                 id: (id++).toString(),
                 weekText: ``,
-                episode: twist.type,
+                episode: { ...twist.type },
                 isValid: true,
             };
-
+            newItem.episode.name = twist.type.name;
             newItems.splice(twist.type.chainable ? chainableInsertAt : nonChainableInsertAt, 0, newItem);
             this.refreshItems(newItems);
         } else {
@@ -233,7 +234,7 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
             }
             this.refreshItems(finalItems);
         }
-        _items = finalItems;
+        _items = _.cloneDeep(finalItems);
         this.setState({ items: finalItems });
         this.props.setTwistsValid(finalItems.every((item) => item.isValid));
     }

--- a/src/components/seasonEditor/seasonEditorList.tsx
+++ b/src/components/seasonEditor/seasonEditorList.tsx
@@ -129,7 +129,7 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
                 isValid: true,
             });
         }
-        _items = elements;
+        !props.loadLast && (_items = elements);
         this.state = props.loadLast ? lastState : { items: elements };
     }
 

--- a/src/components/seasonEditor/seasonEditorList.tsx
+++ b/src/components/seasonEditor/seasonEditorList.tsx
@@ -177,14 +177,14 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
                 const equalTeamsLookupIds = twist.type.teamsLookupId
                     ? twist.type.teamsLookupId === item.episode.teamsLookupId
                     : false;
-                return item.episode === twist.type || equalTeamsLookupIds;
+                return item.episode.name === twist.type.name || equalTeamsLookupIds;
             });
             this.refreshItems(newItems, i);
         }
     }
 
     public componentDidMount() {
-        twistCapacity$.next(this.maxCapacity());
+        !this.props.loadLast && twistCapacity$.next(this.maxCapacity());
         this.subs.push(twist$.subscribe((twist) => this.addRemoveTwist(twist)));
     }
 

--- a/src/components/seasonEditor/seasonEditorList.tsx
+++ b/src/components/seasonEditor/seasonEditorList.tsx
@@ -73,6 +73,7 @@ const ListItem = ({
 interface SeasonEditorListProps {
     castSize: number;
     setTwistsValid: (valid: boolean) => void;
+    loadLast: boolean;
 }
 
 interface SeasonEditorListState {
@@ -107,8 +108,10 @@ function shouldIncrement(items: SeasonEditorListItem[], i: number): boolean {
     return false; // exhausted the list, return false
 }
 
+let lastState: SeasonEditorListState = { items: [] };
+let id = 0;
+
 export class SeasonEditorList extends React.Component<SeasonEditorListProps, SeasonEditorListState> {
-    private id: number = 0;
     private subs: Subscription[] = [];
 
     public constructor(props: SeasonEditorListProps) {
@@ -119,14 +122,14 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
         for (let i = props.castSize; i > 3; i--) {
             week++;
             elements.push({
-                id: (this.id++).toString(),
+                id: (id++).toString(),
                 weekText: `Week ${week}: F${i}`,
                 episode: BigBrotherVanilla,
                 isValid: true,
             });
         }
         _items = elements;
-        this.state = { items: elements };
+        this.state = props.loadLast ? lastState : { items: elements };
     }
 
     private maxCapacity(): number {
@@ -158,7 +161,7 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
                 (value, index, _) => index > 0 && value.episode === BigBrotherVanilla
             );
             const newItem = {
-                id: (this.id++).toString(),
+                id: (id++).toString(),
                 weekText: ``,
                 episode: twist.type,
                 isValid: true,
@@ -186,6 +189,7 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
 
     public componentWillUnmount(): void {
         this.subs.forEach((sub) => sub.unsubscribe());
+        lastState = this.state;
     }
 
     private refreshItems(newItems: SeasonEditorListItem[], addIndex?: number) {
@@ -215,7 +219,7 @@ export class SeasonEditorList extends React.Component<SeasonEditorListProps, Sea
             while (playerCount > 3) {
                 week++;
                 const item = {
-                    id: (this.id++).toString(),
+                    id: (id++).toString(),
                     weekText: `Week ${week || 1}: F${playerCount}`,
                     episode: BigBrotherVanilla,
                     isValid: true,

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -123,7 +123,11 @@ export function SeasonEditorPage(): JSX.Element {
                 </HasText>
                 <hr />
                 <Noselect>
-                    <SeasonEditorList setTwistsValid={setTwistsValid} castSize={castLength} />
+                    <SeasonEditorList
+                        setTwistsValid={setTwistsValid}
+                        castSize={castLength}
+                        loadLast={loadLast}
+                    />
                 </Noselect>
             </div>
             <div className="column" style={{ padding: 20 }}>

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -106,15 +106,16 @@ const submit = async (jury: number, hohPlaysVeto: boolean): Promise<void> => {
 
 export function SeasonEditorPage(): JSX.Element {
     const castLength = getCast().length;
-    const [jurySize, setJurySize] = useState(`${defaultJurySize(castLength)}`);
+    const loadLast = castLength === lastCastLength;
+    const [jurySize, setJurySize] = useState(loadLast ? `${lastJurySize}` : `${defaultJurySize(castLength)}`);
     const validJurySize = validateJurySize(parseInt(jurySize), castLength);
     const [areTwistsValid, setTwistsValid] = useState(true);
     const [hohPlaysVeto, setHohPlaysVeto] = useState(lastHoHPlaysVeto);
     // this is the future react wants
     useEffect(() => () => {
         lastCastLength = castLength;
+        lastJurySize = parseInt(jurySize);
     });
-    const loadLast = castLength === lastCastLength;
     return (
         <div className="columns">
             <div className="column is-one-quarter">

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -114,6 +114,7 @@ export function SeasonEditorPage(): JSX.Element {
     useEffect(() => () => {
         lastCastLength = castLength;
     });
+    const loadLast = castLength === lastCastLength;
     return (
         <div className="columns">
             <div className="column is-one-quarter">
@@ -129,11 +130,7 @@ export function SeasonEditorPage(): JSX.Element {
                 <Subheader>Add Twists</Subheader>
                 <div className="columns is-multiline is-centered">
                     {twists.map((type) => (
-                        <TwistAdder
-                            type={type}
-                            key={`${type.name}${type.emoji}`}
-                            loadFromCache={castLength === lastCastLength}
-                        />
+                        <TwistAdder type={type} key={`${type.name}${type.emoji}`} loadFromCache={loadLast} />
                     ))}
                     <div
                         className="column is-5-desktop is-5-widescreen is-5-fullhd is-12-tablet"
@@ -201,7 +198,7 @@ export function SeasonEditorPage(): JSX.Element {
                     </div>
                 </div>
                 <Subheader>🎌 Add Teams</Subheader>
-                <TeamsAdderList />
+                <TeamsAdderList loadLast={loadLast} />
             </div>
             <div className="column is-narrow" style={{ paddingTop: 20, paddingRight: 20 }}>
                 <button

--- a/src/components/seasonEditor/seasonEditorPage.tsx
+++ b/src/components/seasonEditor/seasonEditorPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { defaultJurySize, GameState, validateJurySize } from "../../model/gameState";
 import { cast$, getCast, newEpisode, pushToMainContentStream, season$ } from "../../subjects/subjects";
@@ -55,6 +55,7 @@ const twists: EpisodeType[] = [
 ];
 
 let lastJurySize = defaultJurySize(16);
+let lastCastLength: number;
 let lastHoHPlaysVeto = true;
 
 export function getLastHoHPlaysVeto(): boolean {
@@ -108,7 +109,11 @@ export function SeasonEditorPage(): JSX.Element {
     const [jurySize, setJurySize] = useState(`${defaultJurySize(castLength)}`);
     const validJurySize = validateJurySize(parseInt(jurySize), castLength);
     const [areTwistsValid, setTwistsValid] = useState(true);
-    const [hohPlaysVeto, setHohPlaysVeto] = useState(true);
+    const [hohPlaysVeto, setHohPlaysVeto] = useState(lastHoHPlaysVeto);
+    // this is the future react wants
+    useEffect(() => () => {
+        lastCastLength = castLength;
+    });
     return (
         <div className="columns">
             <div className="column is-one-quarter">
@@ -124,7 +129,11 @@ export function SeasonEditorPage(): JSX.Element {
                 <Subheader>Add Twists</Subheader>
                 <div className="columns is-multiline is-centered">
                     {twists.map((type) => (
-                        <TwistAdder type={type} key={`${type.name}${type.emoji}`} />
+                        <TwistAdder
+                            type={type}
+                            key={`${type.name}${type.emoji}`}
+                            loadFromCache={castLength === lastCastLength}
+                        />
                     ))}
                     <div
                         className="column is-5-desktop is-5-widescreen is-5-fullhd is-12-tablet"

--- a/src/components/seasonEditor/teamsAdderList.tsx
+++ b/src/components/seasonEditor/teamsAdderList.tsx
@@ -10,21 +10,102 @@ interface TeamsAdderListState {
     id: number;
 }
 
+interface DumpedState {
+    items: {
+        [id: number]: {
+            id: number;
+            Teams: { [id: number]: Tribe };
+            endsWhen: string;
+        };
+    };
+    id: number;
+}
+
 let _teams: { [id: number]: TeamAdderProps } = {};
+let lastState: DumpedState = { items: {}, id: 1 };
 
 export function getTeamsListContents(): { [id: number]: TeamAdderProps } {
     return { ..._teams };
 }
 
-export class TeamsAdderList extends React.Component<{}, TeamsAdderListState> {
-    public constructor(props: {}) {
+export class TeamsAdderList extends React.Component<{ loadLast: boolean }, TeamsAdderListState> {
+    public constructor(props: Readonly<{ loadLast: boolean }>) {
         super(props);
         _teams = {};
-        this.state = { items: {}, id: 1 };
+        this.state = props.loadLast ? this.loadDumpedState() : { items: {}, id: 1 };
     }
 
     public componentDidUpdate(): void {
         _teams = { ...this.state.items };
+    }
+
+    private loadDumpedState(): TeamsAdderListState {
+        const newState: TeamsAdderListState = { id: lastState.id, items: {} };
+        // now for the items
+        for (const itemsKey in lastState.items) {
+            const item = lastState.items[itemsKey];
+            const Teams: { [id: number]: ChangableTeam } = {};
+            for (const teamsKey in item.Teams) {
+                const id = parseInt(itemsKey);
+                const tribeId = parseInt(teamsKey);
+                Teams[teamsKey] = {
+                    ...item.Teams[teamsKey],
+                    onChangeColor: this.getOnChangeColor(id, tribeId),
+                    onChangeName: this.getOnChangeName(id, tribeId),
+                    removeTeam: this.getOnDelete(id, tribeId),
+                };
+            }
+            const id = parseInt(itemsKey);
+            const newItem = {
+                id: item.id,
+                Teams,
+                endsWhen: item.endsWhen,
+                onChangeNumber: (n: string) => {
+                    const newState = { ...this.state };
+                    newState.items[id].endsWhen = n;
+                    this.setState(newState);
+                },
+                deleteSelf: this.getOnDeleteSelf(id),
+                addTeam: () => {
+                    const newState = { ...this.state };
+                    const newTeam = getTribe("", getRandomColor().toHex());
+                    const tribeId = newTeam.tribeId;
+                    newState.items[id].Teams[tribeId] = {
+                        ...newTeam,
+                        onChangeName: this.getOnChangeName(id, tribeId),
+                        onChangeColor: this.getOnChangeColor(id, tribeId),
+                        removeTeam: this.getOnDelete(id, tribeId),
+                    };
+                    newState.id = id + 1;
+                    this.setState(newState);
+                },
+            };
+            newState.items[itemsKey] = newItem;
+        }
+        return newState;
+    }
+
+    public componentWillUnmount(): void {
+        const newLastState: DumpedState = { items: {}, id: this.state.id };
+        for (const itemsKey in this.state.items) {
+            const item = this.state.items[itemsKey];
+            const Teams: { [id: number]: Tribe } = {};
+            for (const teamsKey in item.Teams) {
+                const newTeam: Tribe = {
+                    color: item.Teams[teamsKey].color,
+                    tribeId: item.Teams[teamsKey].tribeId,
+                    name: item.Teams[teamsKey].name,
+                };
+                Teams[teamsKey] = newTeam;
+            }
+
+            newLastState.items[itemsKey] = {
+                id: item.id,
+                Teams,
+                endsWhen: item.endsWhen,
+            };
+        }
+        lastState = newLastState;
     }
 
     private getOnChangeName(id: number, tribeId: number): (name: string) => void {

--- a/src/components/seasonEditor/teamsAdderList.tsx
+++ b/src/components/seasonEditor/teamsAdderList.tsx
@@ -31,7 +31,7 @@ export function getTeamsListContents(): { [id: number]: TeamAdderProps } {
 export class TeamsAdderList extends React.Component<{ loadLast: boolean }, TeamsAdderListState> {
     public constructor(props: Readonly<{ loadLast: boolean }>) {
         super(props);
-        _teams = {};
+        !props.loadLast && (_teams = {});
         this.state = props.loadLast ? this.loadDumpedState() : { items: {}, id: 1 };
     }
 

--- a/src/components/seasonEditor/twistAdder.tsx
+++ b/src/components/seasonEditor/twistAdder.tsx
@@ -14,7 +14,10 @@ export function getEmoji(episode: EpisodeType): string {
 
 interface TwistAdderProps {
     type: EpisodeType;
+    loadFromCache?: boolean;
 }
+
+const cache: { [id: string]: any } = {};
 
 export class TwistAdder extends React.Component<
     TwistAdderProps,
@@ -24,7 +27,8 @@ export class TwistAdder extends React.Component<
 
     public constructor(props: TwistAdderProps) {
         super(props);
-        this.state = { twistCount: 0, twistCapacity: twistCapacity$.value };
+        const twistCount = props.loadFromCache ? cache[this.props.type.name!] || 0 : 0;
+        this.state = { twistCount, twistCapacity: twistCapacity$.value };
         this.subs = [];
     }
 
@@ -34,6 +38,7 @@ export class TwistAdder extends React.Component<
 
     public componentWillUnmount(): void {
         this.subs.forEach((sub) => sub.unsubscribe());
+        cache[this.props.type.name!] = this.state.twistCount;
     }
 
     public render(): JSX.Element {


### PR DESCRIPTION
__New Features:__

- The twist editor saves your twists if you leave and come back, as long as you have the same number of houseguests.

__Bugfixes:__

- Persistent split houses no longer persist after a double eviction style twist merges them. This was causing game crashes. (reported by @Jaelin)
- Fixed a bug where placing a triple eviction on the episode where one evictee is on the jury and the other is not would cause the power rankings view to incorrectly appear and display bugged information.
- Fixed a bug where evicted jurors were appearing black and white instead of sepia in the eviction scene.
